### PR TITLE
remove scorllTo top after page refresh

### DIFF
--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -23,12 +23,6 @@ export default class Home extends Component {
     }
 
     componentDidMount() {
-        // force page scroll position to top when page refresh
-        // this is for avoid parallax animation breaking.
-        window.onbeforeunload = function(){
-            window.scrollTo(0,0);
-        }
-
         if (!this.props.articles) {
             this.props.loadArticles();
         }


### PR DESCRIPTION
After image resizing according to window size,
this prevention is not needed anymore
@hcchien 