### PR TITLE
use className and style object for react component

### DIFF
--- a/src/components/SystemError.js
+++ b/src/components/SystemError.js
@@ -3,13 +3,13 @@ export default class SystemError extends Component {
     render() {
         return (
                 <div>
-                    <div class="nav-menu">
-                        <div class="nav_logo" style="text-align: center;">
+                    <div className="nav-menu">
+                        <div className="nav_logo">
                             <a href="#"><img height="81" src="/asset/logo.png"/></a>
                         </div>
                     </div>
-                    <div style="text-align: center;">
-                        <img class="error_img" src="/asset/500.jpg" width="80%" height="auto"/>
+                    <div style={{textAlign: 'center'}}>
+                        <img className="error_img" src="/asset/500.jpg" width="80%" height="auto"/>
                     </div>
                 </div>
                );


### PR DESCRIPTION
@nickhsine 

- use `className` and `style` object
- remove `text-align` because it's already defined in `.nav_logo` css