### PR TITLE
Bump react-slick version to support react 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-inline-css": "^2.0.0",
     "react-redux": "^2.1.2",
     "react-router": "^1.0.0-rc4",
-    "react-slick": "0.6.6",
+    "react-slick": "0.9.2",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redux": "^3.0.0",

--- a/src/components/TopNews.js
+++ b/src/components/TopNews.js
@@ -44,8 +44,8 @@ export default class TopNews extends Component {
                 }
                 const image = imageComposer(a, device);
                 return (
+                    <div key={a.id}>
                     <a
-                        key={a.id}
                         href={(a.slug) ? "https://www.twreporter.org/a/" + a.slug : a.storyLink}
                         className="topnewsimage-wrap"
                         style={{
@@ -64,6 +64,7 @@ export default class TopNews extends Component {
                             </div>
                         </div>
                     </a>
+                    </div>
                 );
             }.bind(this))}
 	    </Slider>

--- a/src/components/TopNews.js
+++ b/src/components/TopNews.js
@@ -1,75 +1,76 @@
-import React, { Component, PropTypes } from 'react';
-import Category from './Category';
-import Slider from 'react-slick';
-import { ts2yyyymmdd } from '../lib/date-transformer';
-import { imageComposer } from '../lib/image-composer.js';
+import React, { Component } from 'react'
+import Category from './Category'
+import Slider from 'react-slick'
+import { ts2yyyymmdd } from '../lib/date-transformer'
+import { imageComposer } from '../lib/image-composer.js'
 
 if (process.env.BROWSER) {
-    require("./TopNews.css");
+  require('./TopNews.css')
 }
 
 export default class TopNews extends Component {
-    constructor(props, context) {
-        super(props, context)
+  constructor(props, context) {
+    super(props, context)
+  }
+  componentDidMount() {
+    // this.handleResize()
+    // window.addEventListener('resize', this.handleResize);
+  }
+  render() {
+    const { topnews, device } = this.props
+    let settings = {
+      dots: true,
+      infinite: true,
+      speed: 1500,
+      autoplay: true,
+      autoplaySpeed: 4500,
+      arrows: true,
+      slidesToShow: 1,
+      slidesToScroll: 1,
+      lazyLoad: false,
+      useCSS: true
     }
-    componentDidMount() {
-        // this.handleResize()
-        // window.addEventListener('resize', this.handleResize);
-    }
-    render() {
-        const { topnews, device } = this.props
-        let settings = {
-            dots: true,
-            infinite: true,
-            speed: 1500,
-            autoplay: true,
-            autoplaySpeed: 4500,
-            arrows: true,
-            slidesToShow: 1,
-            slidesToScroll: 1,
-            lazyLoad: false,
-            useCSS: true
-        };
-	return Array.isArray(topnews) ? (
-	    <Slider {...settings}>
-            {topnews.map((a) => {
-                const pubDate = ts2yyyymmdd(a.lastPublish * 1000, '.');
-                let tags = a.tags
-                let catDisplay = "專題"
-                for (let i = 0; i < tags.length; i++) {
-                    if (tags[i].substring(0,4) == 'cat:') {
-                        catDisplay = tags[i].substring(4)
-                        break
-                    }
-                }
-                const image = imageComposer(a, device);
-                return (
-                    <div key={a.id}>
-                    <a
-                        href={(a.slug) ? "https://www.twreporter.org/a/" + a.slug : a.storyLink}
-                        className="topnewsimage-wrap"
-                        style={{
-                            backgroundImage: 'url(' + image + ')',
-                        }}
-                        >
-                        <div className="topnews_categorycontainer">
-                            <Category>{catDisplay}</Category>
-                        </div>
-                        <div className="carousel-item">
-                            <div className="carousel-itemsubtitle">{a.subtitle}</div>
-                            <div className="carousel-itemtitle">{a.title}</div>
-                            <div className="carousel-excerpt">{a.excerpt}</div>
-                            <div className="carousel-published">
-                                {pubDate}
-                            </div>
-                        </div>
-                    </a>
-                    </div>
-                );
-            }.bind(this))}
-	    </Slider>
-	) : null;
-    }
+
+    return Array.isArray(topnews) ? (
+      <Slider {...settings}>
+        {topnews.map((a) => {
+          const pubDate = ts2yyyymmdd(a.lastPublish * 1000, '.')
+          let tags = a.tags
+          let catDisplay = '專題'
+          for (let i = 0; i < tags.length; i++) {
+            if (tags[i].substring(0,4) == 'cat:') {
+              catDisplay = tags[i].substring(4)
+              break
+            }
+          }
+          const image = imageComposer(a, device)
+          return (
+            <div key={a.id}>
+              <a
+                href={(a.slug) ? 'https://www.twreporter.org/a/' + a.slug : a.storyLink}
+                className="topnewsimage-wrap"
+                style={{
+                  backgroundImage: 'url(' + image + ')'
+                }}
+              >
+                <div className="topnews_categorycontainer">
+                  <Category>{catDisplay}</Category>
+                </div>
+                <div className="carousel-item">
+                  <div className="carousel-itemsubtitle">{a.subtitle}</div>
+                  <div className="carousel-itemtitle">{a.title}</div>
+                  <div className="carousel-excerpt">{a.excerpt}</div>
+                  <div className="carousel-published">
+                    {pubDate}
+                  </div>
+                </div>
+              </a>
+            </div>
+          )
+        }.bind(this))}
+      </Slider>
+    ) : null
+  }
 }
 
-export { TopNews };
+export { TopNews }


### PR DESCRIPTION
To resolve 'getDOMNode is deprecated' warning.

On react-slick `0.9.2`. Carousel would autoplay when user unfocus page. So I also hack `visibilitychange` to stop autoplay carousel when page is not focus or visible