### PR TITLE
Optimize static resources transfer using gzip compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
+    "compression": "^1.6.0",
     "eslint": "1.8.0",
     "eslint-config-rackt": "^1.1.1",
     "eslint-loader": "^1.0.0",

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,4 @@
+import Compression from 'compression'
 import Express from 'express'
 import path from 'path'
 
@@ -18,6 +19,7 @@ let port = 3000
 
 server.set('views', path.join(__dirname, 'views'))
 server.set('view engine', 'ejs')
+server.use(Compression())
 server.use(Express.static(path.join(__dirname, '.', '../static')))
 server.use(function (req, res, next) {
   res.header('Access-Control-Allow-Origin', 'http://www.twreporter.org/')


### PR DESCRIPTION
Compressing the following resources with gzip could reduce their transfer size by 623.6KiB (71% reduction).

* https://www.twreporter.org/main.js could save 476.6KiB (69% reduction).
* https://www.twreporter.org/asset/ScrollMagic.js could save 77.2KiB (76% reduction).
* https://www.twreporter.org/ could save 58.7KiB (83% reduction).
* https://www.twreporter.org/main.css could save 10.5KiB (78% reduction).
* https://www.twreporter.org/asset/reset.css could save 477B (44% reduction).
* https://www.twreporter.org/ga.js could save 91B (24% reduction).

Reference: https://gtmetrix.com/reports/www.twreporter.org/HaOsB6M3