### PR TITLE
Remove --dev option from the instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ New Media foundation in Taiwan.
 
 # Development
 
-    $ npm install --dev
+    $ npm install
 
 Start the server
 


### PR DESCRIPTION
Summary:

    The `--dev` option leads to 500 error

Related: #77