### PR TITLE
pass device implicitly by React context

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -23,7 +23,7 @@ server.set('view engine', 'ejs')
 server.use(Compression())
 server.use(Express.static(path.join(__dirname, '.', '../static')))
 server.use(function (req, res, next) {
-  r=> es.header('Access-Control-Allow-Origin', 'http://www.twreporter.org/')
+  res.header('Access-Control-Allow-Origin', 'http://www.twreporter.org/')
   res.header('Access-Control-Allow-Headers', 'X-Requested-With')
   next()
 })

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import configureStore from '../src/store/configureStore'
 import crateRoutes from '../src/routes/index'
 
 import { Provider } from 'react-redux'
+import DeviceProvider from '../src/components/DeviceProvider'
 
 let server = new Express()
 let port = 3000
@@ -22,7 +23,7 @@ server.set('view engine', 'ejs')
 server.use(Compression())
 server.use(Express.static(path.join(__dirname, '.', '../static')))
 server.use(function (req, res, next) {
-  res.header('Access-Control-Allow-Origin', 'http://www.twreporter.org/')
+  r=> es.header('Access-Control-Allow-Origin', 'http://www.twreporter.org/')
   res.header('Access-Control-Allow-Headers', 'X-Requested-With')
   next()
 })
@@ -33,7 +34,7 @@ server.use(function (req, res, next) {
 //  let { questions } = require('./mock_api');
 //  res.send(questions);
 //});
-
+//
 server.get('*', (req, res)=> {
   let history = createMemoryHistory()
   let store = configureStore()
@@ -67,11 +68,15 @@ server.get('*', (req, res)=> {
         return promise
       }
 
+      const device = store.getState().device
+
       getReduxPromise().then(()=> {
         let reduxState = escape(JSON.stringify(store.getState()))
         let html = ReactDOMServer.renderToString(
-          <Provider store={store}>
-            { <RoutingContext {...renderProps}/> }
+          <Provider store={store} >
+            <DeviceProvider device={device}>
+              { <RoutingContext {...renderProps}/> }
+            </DeviceProvider>
           </Provider>
         )
 

--- a/src/components/Daily.js
+++ b/src/components/Daily.js
@@ -13,7 +13,7 @@ export default class Daily extends Component {
     }
 
     render() {
-        const { daily, device } = this.props
+        const { daily } = this.props
         let dailyTop = []
         if ( daily ) { dailyTop = daily.slice(0, 6); }
 	return dailyTop ? (

--- a/src/components/DeviceProvider.js
+++ b/src/components/DeviceProvider.js
@@ -1,0 +1,28 @@
+import { Component, PropTypes, Children } from 'react'
+
+export default class DeviceProvider extends Component {
+  getChildContext() {
+    return {
+      device: this.device
+    }
+  }
+
+  constructor(props, context) {
+    super(props, context)
+    this.device = props.device
+  }
+
+  render() {
+    let { children } = this.props
+    return Children.only(children)
+  }
+}
+
+DeviceProvider.propTypes = {
+  children: PropTypes.element.isRequired,
+  device: PropTypes.string.isRequired
+}
+
+DeviceProvider.childContextTypes = {
+  device: PropTypes.string
+}

--- a/src/components/Features.js
+++ b/src/components/Features.js
@@ -14,7 +14,8 @@ export default class Features extends Component {
   }
 
   render() {
-    const { features, device, hasMore, loadMore } = this.props
+    const { features, hasMore, loadMore } = this.props
+    const { device } = this.context
     if (Array.isArray(features)) {
       return (
         <div className="features-list clearfix">
@@ -36,6 +37,11 @@ export default class Features extends Component {
       return ( <div> </div>)
     }
   }
+}
+
+Features.contextTypes = {
+  // store: React.PropTypes.object
+  device: React.PropTypes.string
 }
 
 export { Features }

--- a/src/components/More.js
+++ b/src/components/More.js
@@ -10,7 +10,8 @@ export default class More extends Component {
   }
 
   render() {
-    const { loadMore, device } = this.props
+    const { loadMore } = this.props
+    const { device } = this.context
     let points = '0,0 25,10 50,0'
     let width = 50
     let height = 11
@@ -30,6 +31,11 @@ export default class More extends Component {
       </div>
     )
   }
+}
+
+More.contextTypes = {
+  // store: React.PropTypes.object,
+  device: React.PropTypes.string
 }
 
 export { More }

--- a/src/components/Tags.js
+++ b/src/components/Tags.js
@@ -13,7 +13,7 @@ export default class Tags extends Component {
   }
 
   render() {
-    const { articles, device, hasMore, loadMore } = this.props
+    const { articles, hasMore, loadMore } = this.props
     let cat_display = "台灣"
     if (articles && articles.length > 0) {
       return (
@@ -48,7 +48,7 @@ export default class Tags extends Component {
               })
             }
           </ul>
-          {hasMore ? <More loadMore={loadMore} device={device} /> : null}
+          {hasMore ? <More loadMore={loadMore} /> : null}
         </div>
       )
     } else {

--- a/src/components/TopNews.js
+++ b/src/components/TopNews.js
@@ -17,7 +17,8 @@ export default class TopNews extends Component {
     // window.addEventListener('resize', this.handleResize);
   }
   render() {
-    const { topnews, device } = this.props
+    const { topnews } = this.props
+    const { device } = this.context
     let settings = {
       dots: true,
       infinite: true,
@@ -74,4 +75,8 @@ export default class TopNews extends Component {
   }
 }
 
+TopNews.contextTypes = {
+  //  store: React.PropTypes.object,
+  device: React.PropTypes.string
+}
 export { TopNews }

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -17,8 +17,8 @@ export default class Home extends Component {
     let params = [ 'hp-projects', 'review', 'feature' ]
     return store.dispatch(loadMultiTaggedArticles(params))
   }
-  constructor(props) {
-    super(props)
+  constructor(props, context) {
+    super(props, context)
     this.loadMoreFeatureArticles = this.loadMoreFeatureArticles.bind(this)
   }
 
@@ -35,7 +35,7 @@ export default class Home extends Component {
   }
 
   render() {
-    const { articles, device } = this.props
+    const { articles } = this.props
     const topnews_num = 5
     let topnewsItems = articles.feature && articles.feature.items || []
     let feature = articles['hp-projects'] || {
@@ -56,11 +56,10 @@ export default class Home extends Component {
       return (
         <div>
           <NavBar/>
-          <TopNews topnews={topnewsItems} device={device}/>
-          <Daily daily={dailyItems} device={device} />
+          <TopNews topnews={topnewsItems} />
+          <Daily daily={dailyItems} />
           <Features
             features={featureItems}
-            device={device}
             hasMore={feature.hasMore}
             loadMore={this.loadMoreFeatureArticles}
           />
@@ -75,7 +74,7 @@ export default class Home extends Component {
 }
 
 function mapStateToProps(state) {
-  return { articles: state.articles, device: state.device }
+  return { articles: state.articles }
 }
 
 export { Home }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import createBrowserHistory from 'history/lib/createBrowserHistory'
 import configureStore from './store/configureStore'
 import createRoutes from './routes'
 import { Provider } from 'react-redux'
+import DeviceProvider from './components/DeviceProvider'
 import { createStore, combineReducers } from 'redux'
 import { RoutingContext, match } from 'react-router'
 
@@ -16,15 +17,18 @@ let reduxState;
 if (window.__REDUX_STATE__) {
     try {
         reduxState = JSON.parse(unescape(__REDUX_STATE__));
-    } catch (e) { 
-    }      
-}         
-      
+    } catch (e) {
+    }
+}
+
 const store = configureStore(reduxState);
+const device = store.getState().device
 
 ReactDOM.render((
     <Provider store={store}>
+      <DeviceProvider device={device}>
          { createRoutes(history) }
+      </DeviceProvider>
     </Provider>
 ), document.getElementById('root'));
 


### PR DESCRIPTION
Like ```<Provider store={store} >```,
it use React context to pass store to every children of ```Provider```.
Therefore, we use ```<DeviceProvider device={store.getState().device}>``` to pass device to every component of  ```DeviceProvider```, and then we don't need to pass device as props in every component needed device.
@hcchien 