### PR TITLE
Add padding in open-source-container

### DIFF
--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -44,6 +44,7 @@
 .footer .open-source-container {
     background-color: #ccc;
     height: 30px;
+    padding: 20px 0;
 }
 
 .open-source-container .items {
@@ -69,11 +70,11 @@
     right: 0px;
 }
 
-@media 
-only screen 
-and (max-width : 799px) , 
-only screen 
-and (max-device-width : 799px) { 
+@media
+only screen
+and (max-width : 799px) ,
+only screen
+and (max-device-width : 799px) {
     .footer {
         height: 100%;
     }
@@ -161,4 +162,3 @@ and (max-device-width : 799px) {
     .open-source-container .github {
     }
 }
-


### PR DESCRIPTION
Text is too close to the top of the div area. Add padding to it to look better.
Before:
<img width="757" alt="2016-01-06 12 44 03" src="https://cloud.githubusercontent.com/assets/93509/12121123/aeea68fe-b40e-11e5-99b8-4374ddbd8f4d.png">
After:
<img width="739" alt="2016-01-06 12 44 24" src="https://cloud.githubusercontent.com/assets/93509/12121122/aee5d65e-b40e-11e5-8f7b-57e35a240c37.png">
