### PR TITLE
render different header navbars using css media queries

### DIFF
--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -83,12 +83,15 @@ and (max-device-width : 1035px) {
 
 @media
 only screen
-and (max-width: 414px),
+and (max-width: 768px),
 only screen
-and (max-device-width : 414px) {
+and (max-device-width : 768px) {
   .mobile-nav {
     display: block;
     position: relative;
+  }
+  .desktop-nav {
+    display: none;
   }
   .nav-logo {
     margin-left: 0.7em;

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -37,18 +37,15 @@ export default class NaviBar extends Component {
   _render() {
     return (
       <div>
-        <div className="mobile-nav">
-          {this._renderMobile()}
-        </div>
-        <div className="desktop-nav">
-          <DesktopNavBar {...this.props}/>
-        </div>
+        {this._renderMobile()}
+        {this._renderDesktop()}
       </div>
     )
   }
   render() {
-    const { device } = this.context
-    return  device !== 'mobile' ? this._renderDesktop() : this._renderMobile()
+    // const { device } = this.context
+    // return  device !== 'mobile' ? this._renderDesktop() : this._renderMobile()
+    return this._render()
   }
 }
 


### PR DESCRIPTION
Use media query to render MobileNav for tablets & mobile devices, and render DesktopNav under desktop devices.