### PR TITLE
hit api layer directly, bypass ats

### DIFF
--- a/api/constants.js
+++ b/api/constants.js
@@ -1,7 +1,7 @@
 let config = {
-  API_PROTOCOL: 'https',
-  API_HOST: 'www.twreporter.org',
-  API_PATH: '/api'
+  API_PROTOCOL: 'http',
+  API_HOST: 'api.twreporter.org',
+  API_PATH: ''
 }
 
 export default config


### PR DESCRIPTION
@hcchien 
Because we have add api layer on the FE server (host:port/api/),
we can not send API request  to ATS layer(www.twreporter.org/api/), there will be a collision.
So FE server should hit the API REST server directly without remapping by ATS. 