### PR TITLE
Make process running in the foreground for docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "betterScripts": {
     "start-prod": {
-      "command": "forever start -e err.log ./bin/server.js",
+      "command": "forever -e err.log ./bin/server.js",
       "env": {
         "NODE_PATH": "./server",
         "NODE_ENV": "production",
@@ -28,7 +28,7 @@
       }
     },
     "start-prod-api": {
-      "command": "forever start ./bin/api.js",
+      "command": "forever ./bin/api.js",
       "env": {
         "NODE_PATH": "./api",
         "NODE_ENV": "production",


### PR DESCRIPTION
Because right now forever start the node process in the background, it will make the docker container exited.
We change the npm start script, so the docker container won't exit.
@garfieldduck 