### PR TITLE
add Tags reducer

### DIFF
--- a/spec/actions/tags.test.js
+++ b/spec/actions/tags.test.js
@@ -17,9 +17,7 @@ global.__SERVER__ = true
 
 const middlewares = [ thunk ]
 const mockDefaultStore = {
-  entities: {
-    tags: {}
-  }
+  tags: {}
 }
 const mockStore = configureMockStore(middlewares)
 const mockTagsName = ['mock-tag-1', 'mock-tag-2'];
@@ -55,7 +53,7 @@ describe('tags action', () => {
       })
   })
 
-  it('creates FETCH_TAGS_REQUEST and FETCH_TAGS_FAILURE when fetching article occurs error', () => {
+  it('creates FETCH_TAGS_REQUEST and FETCH_TAGS_FAILURE when fetching tags occurs error', () => {
 
     nock('http://localhost:3030/')
       .get(`/tags/?${query}`)
@@ -76,9 +74,9 @@ describe('tags action', () => {
       })
   })
 
-  it('does not create any action when article is already fetched', () => {
+  it('does not create any action when tags are already fetched', () => {
     const expectedActions = []
-    const store = mockStore(merge({}, mockDefaultStore, normalize(camelizeKeys(mockTags).items, arrayOf(tagSchema))))
+    const store = mockStore(merge({}, mockDefaultStore, { tags: { [mockTagsName[0]]: {}, [mockTagsName[1]]: {} } }))
     expect(store.dispatch(actions.fetchTagsIfNeeded(mockTagsName))).to.equal(undefined);
   })
 })

--- a/spec/reducers/tags.test.js
+++ b/spec/reducers/tags.test.js
@@ -1,0 +1,84 @@
+'use strict'
+import { expect } from 'chai'
+import reducer from '../../src/reducers/tags'
+import * as types from '../../src/constants/action-types'
+
+const mockTagsName = ['mock-tag-1', 'mock-tag-2']
+
+describe('tags reducer', () => {
+  it('should return the initial state', () => {
+    expect(
+      reducer(undefined, {})
+    ).to.deep.equal({})
+  })
+
+  it('should handle FETCH_TAGS_REQUEST', () => {
+    expect(
+      reducer([], {
+        type: types.FETCH_TAGS_REQUEST,
+        tags: mockTagsName
+      })
+    ).to.deep.equal(
+        {
+          [mockTagsName[0]]: {
+            isFetching: true,
+            error: null
+          },
+          [mockTagsName[1]]: {
+            isFetching: true,
+            error: null
+          }
+        }
+    )
+  })
+
+  it('should handle FETCH_TAGS_FAILURE', () => {
+    expect(
+      reducer([], {
+        type: types.FETCH_TAGS_FAILURE,
+        tags: mockTagsName,
+        error: new Error('Test Error'),
+        failedAt: 1234567890
+      })
+    ).to.deep.equal(
+        {
+          [mockTagsName[0]]: {
+            isFetching: false,
+            error: new Error('Test Error'),
+            lastUpdated: 1234567890
+          },
+          [mockTagsName[1]]: {
+            isFetching: false,
+            error: new Error('Test Error'),
+            lastUpdated: 1234567890
+          }
+        }
+    )
+  })
+
+  it('should handle FETCH_TAGS_SUCCESS', () => {
+    expect(
+      reducer([], {
+        type: types.FETCH_TAGS_SUCCESS,
+        response: {
+          entities: {},
+          result: mockTagsName
+        },
+        receivedAt: 1234567890
+      })
+    ).to.deep.equal(
+        {
+          [mockTagsName[0]]: {
+            isFetching: false,
+            error: null,
+            lastUpdated: 1234567890
+          },
+          [mockTagsName[1]]: {
+            isFetching: false,
+            error: null,
+            lastUpdated: 1234567890
+          }
+        }
+    )
+  })
+})

--- a/src/actions/tags.js
+++ b/src/actions/tags.js
@@ -55,10 +55,10 @@ function fetchTags(tags) {
 }
 
 function dedupTags(state, tags) {
-  const existedTags = state.entities.tags
+  const existedTags = state.tags
   let rtn = []
   tags.forEach((tag) => {
-    if (!existedTags.hasOwnProperty(tag)) {
+    if (!existedTags.hasOwnProperty(tag) || existedTags[tag].error ) {
       rtn.push(tag)
     }
   })

--- a/src/reducers/article.js
+++ b/src/reducers/article.js
@@ -1,5 +1,3 @@
-/*eslint no-console: 0*/
-/* global console */
 import * as types from '../constants/action-types'
 
 function article(state = {}, action) {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,9 +2,10 @@ import { combineReducers } from 'redux'
 import { merge } from 'lodash'
 import { routerStateReducer as router } from 'redux-router'
 import * as ActionTypes from '../actions'
-import selectedArticle from './article'
 import articles from './articles'
 import device from './device'
+import selectedArticle from './article'
+import tags from './tags'
 
 // Updates an entity cache in response to any action with response.entities.
 function entities(state = { articlesByTags: {}, selectedArticle: {} }, action) {
@@ -32,6 +33,7 @@ const rootReducer = combineReducers({
   entities,
   device,
   selectedArticle,
+  tags,
   router
 })
 

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -1,0 +1,46 @@
+import * as types from '../constants/action-types'
+
+function tags(state = {}, action) {
+  let _tags = {}
+  switch (action.type) {
+    case types.FETCH_TAGS_REQUEST:
+      action.tags.map((tag) => {
+        _tags[tag] = {
+          error: null,
+          isFetching: true
+        }
+      })
+      return Object.assign({}, state, _tags)
+    case types.FETCH_TAGS_FAILURE:
+      action.tags.map((tag) => {
+        _tags[tag] = {
+          error: action.error,
+          isFetching: false,
+          lastUpdated: action.failedAt
+        }
+      })
+      return Object.assign({}, state, _tags)
+    case types.FETCH_TAGS_SUCCESS:
+      action.response.result.map((tag) => {
+        _tags[tag] = {
+          error: null,
+          isFetching: false,
+          lastUpdated: action.receivedAt
+        }
+      })
+      return Object.assign({}, state, _tags)
+    default:
+      return state
+  }
+}
+
+export default function (state = {}, action) {
+  switch(action.type) {
+    case types.FETCH_TAGS_SUCCESS:
+    case types.FETCH_TAGS_REQUEST:
+    case types.FETCH_TAGS_FAILURE:
+      return tags(state, action)
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
- add tags reducer
- unit test

Tags reducer will not only store the tag objects in ```state.entities``` but also store the fetching situtation in ```state.tags```.

The redux state will be like the following object
```
{
  entities: {
    'mock-tag-1': {
      name: 'mock-tag-1',
      id: 'mongodb-id-1'
      ...
    },
    ...
  },
  tags: {
    'mock-tag-1': {
       isFetching: false,
       error: null, 
       lastUpdated: 1234567890
    }, 
    ...
  }
}
```