### PR TITLE
code refactor

### DIFF
--- a/spec/actions/article.test.js
+++ b/spec/actions/article.test.js
@@ -80,6 +80,6 @@ describe('article action', () => {
 
   it('does not create any action when article is already fetched', () => {
     const store = mockStore(merge({}, mockDefaultStore, { entities: { articles: { [mockSlug]: mockArticle } } }))
-    expect(store.dispatch(actions.fetchArticleIfNeeded(mockSlug))).to.equal(undefined)
+    expect(store.dispatch(actions.fetchArticleIfNeeded(mockSlug))).to.be.an.instanceof(Promise)
   })
 })

--- a/spec/actions/articles.test.js
+++ b/spec/actions/articles.test.js
@@ -1,11 +1,13 @@
-/*global afterEach, describe, it*/
+/*global afterEach, beforeEach, describe, it*/
 'use strict'
 import { expect } from 'chai'
+import { merge } from 'lodash'
 import * as actions from '../../src/actions/articles'
 import * as types from '../../src/constants/action-types'
 import configureMockStore from 'redux-mock-store'
 import mockArticles from './mocks/articles'
 import mockMoreArticles from './mocks/more-articles'
+import mockTags from './mocks/tags'
 import nock from 'nock'
 import thunk from 'redux-thunk'
 import qs from 'qs'
@@ -15,71 +17,96 @@ global.__SERVER__ = true
 
 const middlewares = [ thunk ]
 const mockStore = configureMockStore(middlewares)
-const mockDefaultStore = {
-  taggedArticles: {}
-}
-const mockTagNames = [ '572315331cece3ae858dffe3' ]
+const mockTagNames = [ 'mock-tag-1' ]
+const mockTagIds = [ mockTags._items[0]._id ]
 const mockPage = 1
 const mockMaxResults = 1
 
-let query = qs.stringify(
-  {
-    where: JSON.stringify( {
-      tags: { '$in': mockTagNames }
-    } ),
-    max_results: mockMaxResults,
-    page: mockPage,
-    sort: '-publishedDate',
-    embedded: JSON.stringify( { authors: 1, tags:1, categories:1 } )
-  }
-)
+const mockDefaultStore = {
+  tags: {
+    [ mockTagNames[0] ]: {
+      id: mockTagIds[0],
+      error: null,
+      isFetching: false
+    }
+  },
+  taggedArticles: {}
+}
 
 describe('articles action', () => {
+  let tagQuery
+  let postQuery
+  beforeEach(() => {
+    // mock tags api response
+    tagQuery = { where: JSON.stringify( { name: { '$in': mockTagNames } }) }
+    nock('http://localhost:3030/')
+    .get(`/tags`)
+    .query(tagQuery)
+    .reply(200, mockTags)
+
+    // mock posts api response
+    postQuery = {
+      where: JSON.stringify( {
+        tags: { '$in': mockTagIds }
+      } ),
+      max_results: mockMaxResults,
+      page: mockPage,
+      sort: '-publishedDate',
+      embedded: JSON.stringify( { authors: 1, tags:1, categories:1 } )
+    }
+    nock('http://localhost:3030/')
+      .get('/posts')
+      .query(postQuery)
+      .reply(200, mockArticles)
+  })
+
   afterEach(() => {
     nock.cleanAll()
   })
 
-  it('creates FETCH_ARTICLES_REQUEST and FETCH_ARTICLES_SUCCESS for the first time to load articles', () => {
-    nock('http://localhost:3030/')
-      .get(`/posts?${query}`)
-      .reply(200, mockArticles)
+  it('fetch tag ids by tag name before fetching articles', () => {
+    const store = mockStore({})
+    store.dispatch(actions.fetchArticlesIfNeeded(mockTagNames, mockMaxResults, mockPage)).then(() => {
+      const actions = store.getActions()
+      expect(actions.length).to.equal(3)
+      expect(actions[0].type).to.equal(types.FETCH_TAGS_REQUEST)
+      expect(actions[1].type).to.eqaul(types.FETCH_TAGS_SUCCESS)
+    })
+  })
 
+  it('handles the first time to load articles', () => {
     const expectedActions = [
       { type: types.FETCH_ARTICLES_REQUEST, tags: mockTagNames },
-      { type: types.FETCH_ARTICLES_SUCCESS }
+      { type: types.FETCH_ARTICLES_SUCCESS, tags: mockTagNames }
     ]
     const store = mockStore(mockDefaultStore)
 
     return store.dispatch(actions.fetchArticlesIfNeeded(mockTagNames, mockMaxResults, mockPage))
       .then(() => { // return of async actions
-        const action = store.getActions()[1]
-        expect(store.getActions()[0]).to.deep.equal(expectedActions[0])
-        expect(action.type).to.deep.equal(expectedActions[1].type)
-        expect(action.response).to.be.an('object')
-        expect(action.response.result).to.be.an('array')
-        expect(action.response.result.length).to.equal(1)
-        expect(action.response.entities).to.be.an('object')
-        expect(action.response.entities.articles).to.be.an('object')
-        expect(action.response.entities.articles.hasOwnProperty('i-am-a-slug')).to.be.true
+        const actions = store.getActions()
+        expect(actions[0]).to.deep.equal(expectedActions[0])
+        expect(actions[1].type).to.deep.equal(expectedActions[1].type)
+        expect(actions[1].response).to.be.an('object')
+        expect(actions[1].tags).to.deep.equal(expectedActions[1].tags)
+        expect(actions[1].response.result).to.deep.equal([ 'i-am-a-slug' ])
+        expect(actions[1].response.entities).to.be.an('object')
+        expect(actions[1].response.entities.articles).to.be.an('object')
+        expect(actions[1].response.entities.articles.hasOwnProperty('i-am-a-slug')).to.be.true
+        expect(actions[1].response.entities.tags).to.be.an('object')
+        expect(actions[1].response.links).to.be.an('object')
+        expect(actions[1].response.meta).to.be.an('object')
       })
   })
 
-  it('creates FETCH_ARTICLES_REQUEST and FETCH_ARTICLES_SUCCESS for loading more articles', () => {
+  it('handles loading more articles', () => {
     // mock nextUrl query string
-    let query = qs.stringify(
-      {
-        where: JSON.stringify( {
-          tags: { '$in': mockTagNames }
-        } ),
-        max_results: mockMaxResults,
-        page: mockPage + 1,
-        sort: '-publishedDate',
-        embedded: JSON.stringify( { authors: 1, tags:1, categories:1 } )
-      }
-    )
+    let query = merge({}, postQuery, {
+      page: mockPage + 1
+    })
 
     nock('http://localhost:3030/')
-      .get(`/posts?${query}`)
+      .get('/posts')
+      .query(query)
       .reply(200, mockMoreArticles)
 
     const expectedActions = [
@@ -88,13 +115,21 @@ describe('articles action', () => {
     ]
 
     const store = mockStore({
+      // mock tags object in redux state
+      tags: {
+        [ mockTagNames[0] ]: {
+          id: mockTagIds[0],
+          error: null,
+          isFetching: false
+        }
+      },
       // mock taggedArticles object in redux state
       taggedArticles: {
         [mockTagNames.join()]: {
           isFetching: false,
           error: null,
           // mock nextUrl
-          nextUrl: `http://localhost:3030/posts?${query}`,
+          nextUrl: `http://localhost:3030/posts?${qs.stringify(query)}`,
           articles: [ '572315c51cece3ae858dffe7' ]
         }
       }
@@ -102,21 +137,45 @@ describe('articles action', () => {
 
     return store.dispatch(actions.fetchArticlesIfNeeded(mockTagNames, mockMaxResults, mockPage))
       .then(() => { // return of async actions
-        const action = store.getActions()[1]
-        expect(store.getActions()[0]).to.deep.equal(expectedActions[0])
-        expect(action.type).to.deep.equal(expectedActions[1].type)
-        expect(action.response).to.be.an('object')
-        expect(action.response.result).to.be.an('array')
-        expect(action.response.result.length).to.equal(1)
-        expect(action.response.entities).to.be.an('object')
-        expect(action.response.entities.articles).to.be.an('object')
-        expect(action.response.entities.articles.hasOwnProperty('i-am-a-slug-2')).to.be.true
+        const actions = store.getActions()
+        expect(actions[0]).to.deep.equal(expectedActions[0])
+        expect(actions[1].type).to.deep.equal(expectedActions[1].type)
+        expect(actions[1].response).to.be.an('object')
+        expect(actions[1].response.result).to.be.an('array')
+        expect(actions[1].response.result.length).to.equal(1)
+        expect(actions[1].response.entities).to.be.an('object')
+        expect(actions[1].response.entities.articles).to.be.an('object')
+        expect(actions[1].response.entities.articles.hasOwnProperty('i-am-a-slug-2')).to.be.true
       })
   })
 
-  it('creates FETCH_ARTICLES_REQUEST and FETCH_ARTICLES_FAILURE when fetching article occurs error', () => {
+  it('handles fetching tags occurs error', () => {
+    // clean up nock setting in beforeEach
+    nock.cleanAll()
+
+    // mock tags api response
     nock('http://localhost:3030/')
-      .get(`/posts?${query}`)
+    .get('/tags')
+    .query(tagQuery)
+    .reply(404, {})
+
+    // create an store with empty object of state
+    const store = mockStore({})
+    return store.dispatch(actions.fetchArticlesIfNeeded(mockTagNames, mockMaxResults, mockPage))
+      .then(() => { // return of async actions
+        expect(store.getActions()[0].type).to.equal(types.FETCH_TAGS_REQUEST)
+        expect(store.getActions()[1].type).to.equal(types.FETCH_TAGS_FAILURE)
+        expect(store.getActions()[2].type).to.equal(types.FETCH_ARTICLES_FAILURE)
+      })
+  })
+
+  it('handles fetching articles occurs error', () => {
+    // clean up nock setting in beforeEach
+    nock.cleanAll()
+
+    nock('http://localhost:3030/')
+      .get('/posts')
+      .query(postQuery)
       .reply(404, {})
 
     const expectedActions = [
@@ -134,7 +193,7 @@ describe('articles action', () => {
       })
   })
 
-  it('does not create any action when article is already fetched', () => {
+  it('does not create any action when articles is already fetched', () => {
     const store = mockStore({
       // mock taggedArticles object in redux state
       taggedArticles: {
@@ -147,7 +206,7 @@ describe('articles action', () => {
         }
       }
     })
-    expect(store.dispatch(actions.fetchArticlesIfNeeded(mockTagNames, mockMaxResults, mockPage))).to.equal(undefined)
+    expect(store.dispatch(actions.fetchArticlesIfNeeded(mockTagNames, mockMaxResults, mockPage))).to.be.an.instanceof(Promise)
   })
 })
 

--- a/spec/actions/tags.test.js
+++ b/spec/actions/tags.test.js
@@ -46,8 +46,9 @@ describe('tags action', () => {
         expect(action.response).to.be.an('object')
         expect(action.response.entities).to.be.an('object')
         expect(action.response.entities.tags).to.be.an('object')
-        expect(action.response.entities.tags.hasOwnProperty(mockTagsName[0])).to.be.true
-        expect(action.response.entities.tags.hasOwnProperty(mockTagsName[1])).to.be.true
+        expect(action.response.entities.tags.hasOwnProperty('572315331cece3ae858dffe3')).to.be.true
+        expect(action.response.entities.tags.hasOwnProperty('572315471cece3ae858dffe4')).to.be.true
+        expect(action.response.result).to.deep.equal([ '572315331cece3ae858dffe3', '572315471cece3ae858dffe4' ])
       })
   })
 

--- a/spec/actions/tags.test.js
+++ b/spec/actions/tags.test.js
@@ -75,6 +75,6 @@ describe('tags action', () => {
 
   it('does not create any action when tags are already fetched', () => {
     const store = mockStore(merge({}, mockDefaultStore, { tags: { [mockTagsName[0]]: {}, [mockTagsName[1]]: {} } }))
-    expect(store.dispatch(actions.fetchTagsIfNeeded(mockTagsName))).to.equal(undefined)
+    expect(store.dispatch(actions.fetchTagsIfNeeded(mockTagsName))).to.be.an.instanceof(Promise)
   })
 })

--- a/spec/reducers/tags.test.js
+++ b/spec/reducers/tags.test.js
@@ -58,18 +58,29 @@ describe('tags reducer', () => {
       reducer([], {
         type: types.FETCH_TAGS_SUCCESS,
         response: {
-          entities: {},
-          result: mockTagsName
+          entities: {
+            tags: {
+              'mock-tag-id-1': {
+                name: mockTagsName[0]
+              },
+              'mock-tag-id-2': {
+                name: mockTagsName[1]
+              }
+            }
+          },
+          result: [ 'mock-tag-id-1', 'mock-tag-id-2' ]
         },
         receivedAt: 1234567890
       })
     ).to.deep.equal({
       [mockTagsName[0]]: {
+        id: 'mock-tag-id-1',
         isFetching: false,
         error: null,
         lastUpdated: 1234567890
       },
       [mockTagsName[1]]: {
+        id: 'mock-tag-id-2',
         isFetching: false,
         error: null,
         lastUpdated: 1234567890

--- a/src/actions/article.js
+++ b/src/actions/article.js
@@ -67,5 +67,6 @@ export function fetchArticleIfNeeded(slug) {
     if (shouldFetchArticle(getState(), slug)) {
       return dispatch(fetchArticle(slug))
     }
+    return Promise.resolve()
   }
 }

--- a/src/actions/tags.js
+++ b/src/actions/tags.js
@@ -55,7 +55,7 @@ function fetchTags(tags) {
 }
 
 function dedupTags(state, tags) {
-  const existedTags = state.tags
+  const existedTags = state.tags || {}
   let rtn = []
   tags.forEach((tag) => {
     if (!existedTags.hasOwnProperty(tag) || existedTags[tag].error ) {
@@ -72,5 +72,6 @@ export function fetchTagsIfNeeded(tags) {
     if (deduppedTags.length !== 0) {
       return dispatch(fetchTags(deduppedTags))
     }
+    return Promise.resolve()
   }
 }

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -21,8 +21,10 @@ function tags(state = {}, action) {
       })
       return Object.assign({}, state, _tags)
     case types.FETCH_TAGS_SUCCESS:
-      action.response.result.map((tag) => {
-        _tags[tag] = {
+      let tagEntities = action.response.entities.tags
+      Object.keys(tagEntities).map((tagEntityId) => {
+        _tags[tagEntities[tagEntityId].name] = {
+          id: tagEntityId,
           error: null,
           isFetching: false,
           lastUpdated: action.receivedAt

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -3,7 +3,7 @@ import { Schema, arrayOf } from 'normalizr'
 
 const author = new Schema('authors')
 const category = new Schema('categories')
-const tag = new Schema('tags', { idAttribute: 'name' })
+const tag = new Schema('tags')
 
 const article = new Schema('articles', { idAttribute: 'slug' })
 


### PR DESCRIPTION
# data structure change of redux state
- change the schema of tag, use ```id```, rather than ```name``` as ```idAttribute```
- in redux state, the difference demonstrates in the following code
```
// it's a redux state
// state.tags looks like the following before code change
{
  entities: {
    tags: {
      'tag-name-1': {
         ...
      },
      'tag-name-2': {
        ...
      }
    }
  }
  tags: {
    'tag-name-1': {
       isFetching: false,
       error: null
    },
    'tag-name-2': {
       ...
    }
  }
}

// after code change it will look like
{
  entities: {
    tags: {
      'tag-id-1': {
         ...
      },
      'tag-id-2': {
        ...
      }
    }
  }
  tags: {
    'tag-name-1': {
       id: 'tag-id-1',
       isFetching: false,
       error: null
    },
    'tag-name-2': {
       ...
    }
  }
}
```

# fetch tag ids by tag name before fetching tagged articles
Loading tagged articles accepts tag names, and fetch tag ids by tag names first before fetching articles.
There will be more error handling for fetching tag ids, like ```dispatch failToReceiveArticles``` action if there is no tag ids loaded.
And the API url is generated by tag ids as well.

@hcchien 