### PR TITLE
Bugs fix

### DIFF
--- a/src/reducers/groups.js
+++ b/src/reducers/groups.js
@@ -1,4 +1,5 @@
 import * as types from '../constants/action-types'
+import _ from 'lodash'
 
 function groups(state = {}, action = {}) {
   let _groups = {}
@@ -26,9 +27,9 @@ function groups(state = {}, action = {}) {
     case types.FETCH_CATEGORIES_SUCCESS:
       let entities
       if (action.type === types.FETCH_TAGS_SUCCESS) {
-        entities = action.response.entities.tags
+        entities = _.get(action, [ 'response', 'entities', 'tags' ], [])
       } else {
-        entities = action.response.entities.categories
+        entities = _.get(action, [ 'response', 'entities', 'categories' ], [])
       }
 
       Object.keys(entities).map((entityId) => {

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -21,7 +21,7 @@ module.exports = {
   entry: {
     'main': [
       'webpack-hot-middleware/client?path=http://' + host + ':' + port + '/__webpack_hmr',
-      'bootstrap-loader',
+      'bootstrap-loader/extractStyles',
       './src/index.js'
     ]
   },
@@ -90,6 +90,8 @@ module.exports = {
       __DEVELOPMENT__: true,
       __DEVTOOLS__: true  // <-------- DISABLE redux-devtools HERE
     }),
+    // css files from the extract-text-plugin loader
+    new ExtractTextPlugin('[name].css'),
     webpackIsomorphicToolsPlugin.development()
   ]
 };


### PR DESCRIPTION
1. extract bootstrap styles from inline to file to fix the problem of rendering react components before loading bootstrap css.

2. use lodash to ```get``` and ```set``` from and into object.