### PR TITLE
Set page types for header and fix topic popup

### DIFF
--- a/src/components/article/BottomRelateds.js
+++ b/src/components/article/BottomRelateds.js
@@ -2,6 +2,7 @@
 'use strict'
 import _ from 'lodash'
 import { CHARACTERS_LIMIT, RELATED_ARTICLES, LOAD_MORE_ARTICLES, ITEMS_LIMIT } from '../../constants/index'
+import { Link } from 'react-router'
 import { shortenString } from '../../lib/string-processor'
 import classNames from 'classnames'
 import commonStyles from '../article/Common.scss'
@@ -67,7 +68,7 @@ export class BottomRelateds extends Component {
 
       return (  
         <li className={classNames(styles.relatedItem, itemDisplayClass)} key={'related-' + (index++)}>
-          <a className={styles.relatedAnchor} href={'/a/' + related.slug}>
+          <Link className={styles.relatedAnchor} to={'/a/' + related.slug}>
             <div className={styles.relatedImgWrapper}>
               <div className={styles.relatedImg}>
                 <LazyLoad>
@@ -79,7 +80,7 @@ export class BottomRelateds extends Component {
               <p className={styles.relatedTitle} dangerouslySetInnerHTML={ this._setHtml(related.title) }></p>
               <p className={styles.relatedDescription}>{shortenString(description, CHARACTERS_LIMIT.BOTTOM_RELATED_DESC)}</p>
             </div>
-          </a>
+          </Link>
         </li>
       )
     })

--- a/src/components/navigation/NavMenu.js
+++ b/src/components/navigation/NavMenu.js
@@ -51,11 +51,13 @@ export default class NavMenu extends Component {
 
     if(nextProps.pageTitle !== this.props.pageTitle) {
       this.setState({ trimmedTitle: '' })
+      this._checkIfPopupShown(this.state.isOpen)
     }
 
     // close the topic popup if user switch to different page
     if(nextProps.path !== this.props.path) {
-      this._onTopicBtnClick()
+      this.setState({ trimmedTitle: '', isTopicOpen: false })
+      this._checkIfPopupShown(this.state.isOpen)
     }
 
     if(this.state.trimmedTitle=='') {
@@ -114,6 +116,9 @@ export default class NavMenu extends Component {
     const { trimmedTitle } = this.state   // trimmed title
     const { pageTopic } = this.props
     let topicBox = pageTopic ? <span className={commonStyles['topic-box']}>{pageTopic}</span> : null
+    let topicButton = pageTopic ? <div className={navItemClass} url={cUrl} appId={appId} onClick={this._onTopicBtnClick}>
+            <img src={tocIcon} />
+          </div> : null
 
     return (
       <div className={classNames(styles.navContainer, styles.slidedUpNav)}>
@@ -128,9 +133,7 @@ export default class NavMenu extends Component {
           </div>
         </div>
         <div className={classNames(styles.navRight, styles.fadeLeft)}>
-          <div className={navItemClass} url={cUrl} appId={appId} onClick={this._onTopicBtnClick}>
-            <img src={tocIcon} />
-          </div>
+          {topicButton}
         </div>
       </div>
     )
@@ -139,7 +142,10 @@ export default class NavMenu extends Component {
   _onTopicBtnClick() {
     const isOpen = !this.state.isTopicOpen
     this.setState({ isTopicOpen: isOpen })
-    
+    this._checkIfPopupShown(isOpen)
+  }
+
+  _checkIfPopupShown(isOpen) {
     // disable the page scrolling function if the Topic popup is being open
     if(isOpen) {
       document.body.style.overflow = 'hidden'

--- a/src/containers/Category.js
+++ b/src/containers/Category.js
@@ -3,6 +3,7 @@ import { CATEGORY, CULTURE_CH_STR, INTL_CH_STR, MEDIA_CH_STR, REVIEW_CH_STR, TAI
 import { connect } from 'react-redux'
 import { denormalizeArticles, getCatId } from '../utils/index'
 import { fetchArticlesByUuidIfNeeded } from '../actions/articles'
+import { setPageType } from '../actions/header'
 import _ from 'lodash'
 import Footer from '../components/Footer'
 import React, { Component } from 'react'
@@ -55,6 +56,10 @@ export default class Category extends Component {
       max_results: MAXRESULT
     })
 
+  }
+
+  componentDidMount() {
+    this.props.setPageType(CATEGORY)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -113,4 +118,4 @@ Category.contextTypes = {
 }
 
 export { Category }
-export default connect(mapStateToProps, { fetchArticlesByUuidIfNeeded })(Category)
+export default connect(mapStateToProps, { fetchArticlesByUuidIfNeeded, setPageType })(Category)

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -1,10 +1,11 @@
 /*eslint no-unused-vars:0, no-console:0 */
 /* global __DEVELOPMENT__ */
 'use strict'
-import { CATEGORY, REVIEW_CH_STR, SPECIAL_TOPIC_CH_STR } from '../constants/index'
+import { HOME, CATEGORY, REVIEW_CH_STR, SPECIAL_TOPIC_CH_STR } from '../constants/index'
 import { connect } from 'react-redux'
 import { denormalizeArticles, getCatId } from '../utils/index'
 import { fetchArticlesByUuidIfNeeded, fetchFeatureArticlesIfNeeded } from '../actions/articles'
+import { setPageType } from '../actions/header'
 import _ from 'lodash'
 import Daily from '../components/Daily'
 import Features from '../components/Features'
@@ -65,6 +66,10 @@ export default class Home extends Component {
     this.specialTopicListId = getCatId(SPECIAL_TOPIC_CH_STR)
     this.reviewListId = getCatId(REVIEW_CH_STR)
     this.loadMoreArticles = this._loadMoreArticles.bind(this, this.specialTopicListId)
+  }
+
+  componentDidMount() {
+    this.props.setPageType(HOME)
   }
 
   componentWillMount() {
@@ -139,5 +144,6 @@ export { Home }
 
 export default connect(mapStateToProps, {
   fetchArticlesByUuidIfNeeded,
-  fetchFeatureArticlesIfNeeded
+  fetchFeatureArticlesIfNeeded,
+  setPageType
 })(Home)

--- a/src/containers/Tag.js
+++ b/src/containers/Tag.js
@@ -3,6 +3,7 @@ import { TAG } from '../constants/index'
 import { connect } from 'react-redux'
 import { denormalizeArticles } from '../utils/index'
 import { fetchArticlesByUuidIfNeeded } from '../actions/articles'
+import { setPageType } from '../actions/header'
 import _ from 'lodash'
 import Footer from '../components/Footer'
 import React, { Component } from 'react'
@@ -42,6 +43,10 @@ export default class Tag extends Component {
       max_results: MAXRESULT
     })
 
+  }
+
+  componentDidMount() {
+    this.props.setPageType(TAG)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -100,4 +105,4 @@ Tag.contextTypes = {
 }
 
 export { Tag }
-export default connect(mapStateToProps, { fetchArticlesByUuidIfNeeded })(Tag)
+export default connect(mapStateToProps, { fetchArticlesByUuidIfNeeded, setPageType })(Tag)

--- a/src/containers/Topic.js
+++ b/src/containers/Topic.js
@@ -3,6 +3,7 @@ import { TOPIC } from '../constants/index'
 import { connect } from 'react-redux'
 import { denormalizeArticles } from '../utils/index'
 import { fetchArticlesByUuidIfNeeded } from '../actions/articles'
+import { setPageType } from '../actions/header'
 import _ from 'lodash'
 import Footer from '../components/Footer'
 import React, { Component } from 'react'
@@ -18,6 +19,10 @@ export default class Topic extends Component {
     this.state = {
       topicId: props.params.topicId
     }
+  }
+
+  componentDidMount() {
+    this.props.setPageType(TOPIC)
   }
 
   componentWillMount() {
@@ -66,4 +71,4 @@ Topic.contextTypes = {
 }
 
 export { Topic }
-export default connect(mapStateToProps, { fetchArticlesByUuidIfNeeded })(Topic)
+export default connect(mapStateToProps, { fetchArticlesByUuidIfNeeded, setPageType })(Topic)


### PR DESCRIPTION
- set page types for Home, Category, Tag, Topic
- avoid topic popup being shown in non-topic pages