### PR TITLE
Refine topic list on the menu and in the bottom of an article

### DIFF
--- a/src/actions/header.js
+++ b/src/actions/header.js
@@ -21,9 +21,10 @@ export function setPageType(pageType) {
   }
 }
 
-export function setPageTitle(pageTitle, pageTopic=null) {
+export function setPageTitle(articleId, pageTitle, pageTopic=null) {
   return {
     type: types.SET_PAGE_TITLE,
+    articleId: articleId,
     pageTitle: pageTitle,
     pageTopic: pageTopic
   }

--- a/src/components/article/BottomRelateds.js
+++ b/src/components/article/BottomRelateds.js
@@ -51,15 +51,19 @@ export class BottomRelateds extends Component {
   }
 
   render() {
-    const { relateds, topicName, topicArr } = this.props
+    const { relateds, topicName, topicArr, currentId } = this.props
     const { isCollapse } = this.state
 
     const titleText = (topicArr && topicName) ? topicName : RELATED_ARTICLES
-    const listItems = (topicArr && topicName) ? topicArr : relateds
+    let listItems = (topicArr && topicName) ? topicArr : relateds
 
     if (!_.get(relateds, '0')) {
       return null
     }
+
+    // find unique items and filter out the current article in display
+    listItems = _.uniq(listItems)
+    listItems = _.filter(listItems, (related) => { return related.id!==currentId })
 
     const relatedRows = _.map(listItems, (related, index) => {
       let imageUrl = _.get(related, 'heroImage.image.resizedTargets.mobile.url', '/asset/review.png')
@@ -85,7 +89,7 @@ export class BottomRelateds extends Component {
       )
     })
 
-    const loadMoreBtn = isCollapse ? null : <div className={classNames(styles.loadMore, 'text-center')} onClick={()=>{this.setState({ isCollapse: true })}}>
+    const loadMoreBtn = isCollapse || listItems.length <= ITEMS_LIMIT.ARTICLE_RELATED ? null : <div className={classNames(styles.loadMore, 'text-center')} onClick={()=>{this.setState({ isCollapse: true })}}>
             {LOAD_MORE_ARTICLES}
           </div>
 

--- a/src/components/navigation/NavMenu.js
+++ b/src/components/navigation/NavMenu.js
@@ -119,11 +119,15 @@ export default class NavMenu extends Component {
   _renderAritcleSecond(burgerMenu, cUrl) {
     const navItemClass = styles.navButton
     const { trimmedTitle } = this.state   // trimmed title
-    const { pageTopic } = this.props
-    let topicBox = pageTopic ? <span className={commonStyles['topic-box']}>{pageTopic}</span> : null
+    const { pageTopic, header } = this.props
+    const topicLength = _.get(header, 'topicArr', []).length
+    const titleClass= pageTopic ? styles['topicTitleText'] : styles['articleTitleText']
+    let topicRedBox = pageTopic ? <span className={commonStyles['topic-box']}>{pageTopic}</span> : null
+    let topicCnt = (topicLength > 0) ? <div className={styles['topic-count']}> {topicLength} </div> : null
     let topicButton = pageTopic ? <div className={navItemClass} url={cUrl} appId={appId} onClick={this._onTopicBtnClick}>
-            <img src={tocIcon} />
+            <img src={tocIcon} /> {topicCnt}
           </div> : null
+   
 
     return (
       <div className={classNames(styles.navContainer, styles.slidedUpNav)}>
@@ -132,13 +136,14 @@ export default class NavMenu extends Component {
           <DonateButton isSlidedUp={true}/>
         </div>
         <div className={classNames(styles.articleTitle, styles.fadeRight)}>
-          <div className={classNames(styles.articleTitleText)} ref="title">
-            {topicBox}
+          <div className={titleClass} ref="title">
+            {topicRedBox}
             {trimmedTitle}
           </div>
         </div>
         <div className={classNames(styles.navRight, styles.fadeLeft)}>
           {topicButton}
+          
         </div>
       </div>
     )
@@ -175,7 +180,7 @@ export default class NavMenu extends Component {
   }
 
   render() {
-    const { path, bgStyle, header, isScrolledOver, pageTopic } = this.props
+    const { path, bgStyle, header, isScrolledOver, pageTopic, articleId } = this.props
     const cUrl = getAbsPath(this.context.location.pathname, this.context.location.search)
     let backgroundColor = colors.whiteBg
     let navTopBackground = isScrolledOver ? colors.superWhite : colors.whiteBg
@@ -187,6 +192,7 @@ export default class NavMenu extends Component {
     let navOuterClass = ''
     let subNavBar = null
     let searchClass = ''
+    let topicPopup = null
 
     // generate category navigation bar
     let navItems = [].concat(navPath)
@@ -247,6 +253,14 @@ export default class NavMenu extends Component {
       navOuterClass = navCommonStyles['nav-scrolled-outer']
     }
 
+    if (header.pageType === ARTICLE && pageTopic) {
+      topicPopup = <TopicPopup isOpen={this.state.isTopicOpen}
+          topicArr={header.topicArr}
+          pageTopic={pageTopic}
+          articleId={articleId}
+          onTopicBtnClick={this._onTopicBtnClick}/>
+    }
+
     return (
       <div style={{ backgroundColor: backgroundColor }}>
         <div className={classNames(navCommonStyles['nav-menu'], navOuterClass)} style={{ backgroundColor: navTopBackground }}>
@@ -254,10 +268,7 @@ export default class NavMenu extends Component {
           {searchBox}
           {subNavBar}
         </div>
-        <TopicPopup isOpen={this.state.isTopicOpen}
-          topicArr={header.topicArr}
-          pageTopic={pageTopic}
-          onTopicBtnClick={this._onTopicBtnClick}/>
+        {topicPopup}
       </div>
     )
   }

--- a/src/components/navigation/NavMenu.scss
+++ b/src/components/navigation/NavMenu.scss
@@ -65,10 +65,17 @@
     }
 }
 
-.articleTitleText {
+.titleText {
     color: $gray-15;
     font-weight: $font-weight-bold;
     font-size: $font-size-base;
+}
+.articleTitleText {
+    @extend .titleText;
+    transform: translateX(-33%);
+}
+.topicTitleText {
+    @extend .titleText;
     transform: translateX(-25%);
 }
 
@@ -228,6 +235,7 @@
     padding: 0;
     cursor: pointer;
     user-select: none;
+    position: relative;
     img {
         width: 100%;
         height: auto;
@@ -239,6 +247,17 @@
             margin-left: -5%;
             margin-top: -10%;
         }
+    }
+    .topic-count {
+        position: absolute;
+        top: rem(-5px);
+        right: rem(-12px);
+        font-size: $font-size-tiny;
+        border-radius: 5rem;
+        width: 0.9rem;
+        height: 0.9rem;
+        background: $primary-color;
+        color: $white;
     }
 }
 

--- a/src/components/navigation/TopicPopup.js
+++ b/src/components/navigation/TopicPopup.js
@@ -3,34 +3,37 @@ import { Link } from 'react-router'
 import { LINK_PREFIX, CHARACTERS_LIMIT, CONTINUE_READING } from '../../constants/index'
 import { shortenString } from '../../lib/string-processor'
 import classNames from 'classnames'
+import commonStyles from '../article/Common.scss'
 import closeIcon from '../../../static/asset/icon-navbar-close.svg'
 import LazyLoad from 'react-lazy-load'
 import React, { Component } from 'react'
 import styles from './TopicPopup.scss'
 
 const Topic = (props) => {
-  const { data } = props
+  const { data, articleId } = props
+  const isCurrentViewing = _.get(data, 'id', '') === articleId
   const link =  LINK_PREFIX.ARTICLE + _.get(data, 'slug', '')
   const heroImgUrl = _.get(data, [ 'heroImage', 'image', 'resizedTargets', 'mobile', 'url' ], null)
+  const currentClass = isCurrentViewing ? styles['current'] : null
 
-  return (
-    <div className="col-md-12 col-lg-6">
-      <div className={styles['topic']}>
-        <div className={styles['img-outer']}>
-          <Link to={link}>
+  const topic = <div className={classNames(styles['topic'], currentClass)}>
+          <div className={styles['img-outer']}>
             <div className={styles['img-box']}>
               <LazyLoad>
                 <img className={styles['crop']} src={heroImgUrl}/>
               </LazyLoad>
             </div>
-          </Link>
+          </div>
+          <div className={styles['text-box']}>
+            <h3 className={styles['article-title']}>{data.title}</h3>
+            <p className={styles['article-desc']}>{shortenString(data.ogDescription, CHARACTERS_LIMIT.TOPIC_DESC)}</p>
+          </div>
         </div>
-        <div className={styles['text-box']}>
-          <Link to={link}><h3 className={styles['article-title']}>{data.title}</h3></Link>
-          <p className={styles['article-desc']}>{shortenString(data.ogDescription, CHARACTERS_LIMIT.TOPIC_DESC)}</p>
-          <Link to={link} className={styles['continue']}>{CONTINUE_READING}</Link>
-        </div>
-      </div>
+  const topicBox = isCurrentViewing ? <div> { topic } </div> : <Link to={link}> { topic } </Link>
+
+  return (
+    <div className="col-md-12 col-lg-6">
+      {topicBox}
     </div>
   )
 }
@@ -41,13 +44,13 @@ export default class TopicPopup extends Component {
   }
 
   render() {
-    const { isOpen, onTopicBtnClick, pageTopic, topicArr } = this.props
-
+    const { isOpen, onTopicBtnClick, pageTopic, topicArr, articleId } = this.props
+    const uniqTopics = _.uniq(topicArr)
     let displayClass = isOpen ? styles.open : styles.close
     let topicList = []
 
-    for(let i=0; i<topicArr.length; i++) {
-      topicList.push(<Topic key={i} data={topicArr[i]} />)
+    for(let i=0; i<uniqTopics.length; i++) {
+      topicList.push(<Topic key={i} data={uniqTopics[i]} articleId={articleId}/>)
     }
 
     return (

--- a/src/components/navigation/TopicPopup.scss
+++ b/src/components/navigation/TopicPopup.scss
@@ -24,6 +24,10 @@
   padding-bottom: 3rem;
 }
 
+.current {
+  opacity: 0.45;
+}
+
 .open {
   max-height: 100%;
   opacity: 1;
@@ -116,6 +120,13 @@
 .topic {
   display: table;
   line-height: rem(23px);
+  width: 100%;
+  transition: background-color 0.2s ease-in;
+  padding: 0 0.5rem 1rem 0.5rem;
+
+  &:hover {
+    background-color: $light-gray;
+  }
 
   @media (max-width: $screen-md-min) {
     margin: 1rem 0.3rem;

--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -57,9 +57,9 @@ class Article extends Component {
 
     const { fetchRelatedArticlesIfNeeded, setPageTitle, selectedArticle, entities } = this.props
 
-    const { topicId } = this.state
+    const { topicId, articleId } = this.state
     if (!selectedArticle.error && !selectedArticle.isFetching &&
-        this.state.articleId !== selectedArticle.id ) {
+        articleId !== selectedArticle.id ) {
 
       // set article ID
       this.setState({ articleId: selectedArticle.id })
@@ -69,7 +69,7 @@ class Article extends Component {
       this.setState({ topicName: topicName })
 
       // set navbar title for this article
-      setPageTitle(_.get(entities, [ 'articles', selectedArticle.id, 'title' ], ''), topicName)
+      setPageTitle(selectedArticle.id, _.get(entities, [ 'articles', selectedArticle.id, 'title' ], ''), topicName)
       // fetch related articles
       let relatedIds = _.get(entities, [ 'articles', selectedArticle.id, 'relateds' ], [])
       fetchRelatedArticlesIfNeeded(selectedArticle.id, relatedIds)
@@ -105,7 +105,7 @@ class Article extends Component {
     }
 
     let tArr = []
-    if(topicId && !topicArr) {
+    if(topicId) {
       _.forEach(entities.articles, function (value, key) {
         if(_.get(value, 'topics') === topicId) {
           tArr.push(value)
@@ -243,6 +243,7 @@ class Article extends Component {
               </div>
               <ArticleComponents.BottomRelateds
                 relateds={article.relateds}
+                currentId={article.id}
                 topicName={topicName}
                 topicArr={topicArr}
               />

--- a/src/containers/NavBar.js
+++ b/src/containers/NavBar.js
@@ -68,6 +68,7 @@ class NaviBar extends Component {
           isScrolledOver={this.state.isScrolledOver}
           pageTitle={this.props.header.pageTitle}
           pageTopic={this.props.header.pageTopic}
+          articleId={this.props.header.articleId}
           />
       </div>
     )

--- a/src/reducers/header.js
+++ b/src/reducers/header.js
@@ -16,6 +16,7 @@ function header(state = {}, action) {
     case types.SET_PAGE_TITLE:
       return {
         ...state,
+        articleId: action.articleId,
         pageTitle: action.pageTitle,
         pageTopic: action.pageTopic
       }


### PR DESCRIPTION
- avoid duplications in display
- show disabled link for the current article in display on the TopicPopup
- hide current article in display in BottomRelated
- avoid showing load more if related items are less than the limit