### PR TITLE
Make Embedded align center even if it is too small

### DIFF
--- a/src/components/article/Body.js
+++ b/src/components/article/Body.js
@@ -18,21 +18,35 @@ export class Body extends Component {
 
     if (Array.isArray(data)) {
       let Blocks = data.map((ele) => {
+        let anchor = null
+        let styles = {}
         let type = ele.type
         let Component = getArticleComponent(type)
-        let anchor = null
+
         if(type === 'header-one') {
           sectionCnt++
           anchor = <div id={`section-${sectionCnt}`} className={styles['anchor']}></div>
+        } else if (type === 'embeddedcode') {
+          let embeddedContent = _.get(ele, [ 'content', 0 ], {})
+          let width = _.get(embeddedContent, 'width')
+          let height = _.get(embeddedContent, 'height')
+          if (width) {
+            styles.maxWidth = width
+          }
+          if (height) {
+            styles.minHeight = height
+          }
         }
 
         if (!Component) {
           return null
         }
+
         return (
           <div
             key={ele.id}
             className={classNames(commonStyles['component'], commonStyles[type])}
+            style={styles}
           >
             {anchor}
             <Component

--- a/src/components/article/Common.scss
+++ b/src/components/article/Common.scss
@@ -62,9 +62,9 @@ $inner-block-margin: $component-margin-left;
     .component {
       margin-left: auto;
       margin-right: auto;
-      width: $tablet-small-width;
+      max-width: $tablet-small-width;
       &.image, &.imagediff, &.slideshow, &.embeddedcode, &.youtube {
-        width: $tablet-medium-width;
+        max-width: $tablet-medium-width;
       }
     }
   }
@@ -90,9 +90,9 @@ $inner-block-margin: $component-margin-left;
     .component {
       margin-left: auto;
       margin-right: auto;
-      width: $desktop-small-width;
+      max-width: $desktop-small-width;
       &.image, &.imagediff, &.slideshow, &.embeddedcode, &.youtube {
-        width: $desktop-medium-width;
+        max-width: $desktop-medium-width;
       }
     }
   }


### PR DESCRIPTION
[Reference: Get iframe height and width while editing.](https://github.com/twreporter/keystone/pull/103) 
And then we can use width and height to align the iframe well.
@garfieldduck 