### PR TITLE
[Update] Use react-hot-loader v3-beta

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,9 @@
           }
         ]
       ]
+    },
+    "DEV": {
+      "plugins": ["react-hot-loader/babel"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "mocha": "^2.3.3",
     "nock": "^2.17.0",
     "precommit-hook": "^3.0.0",
-    "react-hot-loader": "^1.3.0",
+    "react-hot-loader": "^3.0.0-beta.6",
     "react-transform-hmr": "^1.0.1",
     "rimraf": "^2.5.2",
     "sinon": "^1.17.1",

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -36,7 +36,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,
-        loaders: [ 'react-hot', 'babel-loader' ]
+        loaders: [ 'babel-loader' ]
       },
       { test:/\.json$/,
         loader: 'json-loader'
@@ -79,7 +79,8 @@ module.exports = {
     new webpack.IgnorePlugin(/webpack-stats\.json$/),
     new webpack.DefinePlugin({
       'process.env': {
-        BROWSER: true
+        BROWSER: true,
+        BABEL_ENV: '"DEV"'  // <-------- TO ENABLE react-hot-loader
       },
       __CLIENT__: true,
       __SERVER__: false,


### PR DESCRIPTION
Which is compatible with react v15.4.x (`react-hot-loader` is used in dev mode)

Ref: [“module not found : Error: Cannot resolve module 'react/lib/ReactMount' ”](http://stackoverflow.com/questions/40652327/module-not-found-error-cannot-resolve-module-react-lib-reactmount)