### PR TITLE
[Update] Update package.json. Replace forever with pm2 and give the --max_old_space_size directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "betterScripts": {
     "start-prod": {
-      "command": "forever -e err.log ./bin/server.js",
+      "command": "pm2 start ./bin/server.js --node-args='--max_old_space_size=2048'",
       "env": {
         "NODE_PATH": "./server",
         "NODE_ENV": "production",
@@ -32,7 +32,7 @@
       }
     },
     "start-prod-api": {
-      "command": "forever -e api-err.log ./bin/api.js",
+      "command": "pm2 start ./bin/api.js --node-args='--max_old_space_size=2048'",
       "env": {
         "NODE_PATH": "./api",
         "NODE_ENV": "production",
@@ -124,7 +124,6 @@
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^0.9.1",
     "file-loader": "^0.9.0",
-    "forever": "^0.15.1",
     "history": "^2.1.2",
     "http-proxy": "^1.12.0",
     "humps": "^0.6.0",
@@ -136,6 +135,7 @@
     "node-sass": "^3.7.0",
     "normalizr": "^1.0.0",
     "piping": "^0.3.0",
+    "pm2": "^2.2.3",
     "postcss-loader": "^0.9.1",
     "pretty-error": "^2.0.0",
     "qs": "^5.2.0",


### PR DESCRIPTION
## Problem on Production : JavaScript heap out of memory
**Temporary solution** 
1. replace forever with pm2 ( to see logs easily)
2. Add --max_old_space_size to increase memory size to 2GB.

The right solution needs more logs,  so currently use this change to monitor the production. 

@garfieldduck 
