### PR TITLE
[Update] Update processes.json. Add max_memory_restart and increase the --max_old_space_size

### DIFF
--- a/processes.json
+++ b/processes.json
@@ -2,6 +2,7 @@
   "apps" : [{
     "name"        : "server",
     "script"      : "bin/server.js",
+    "max_memory_restart": "4G",
     "env"         : {
       "NODE_PATH": "./server",
       "NODE_ENV": "production",
@@ -11,10 +12,11 @@
       "APIPROTOCOL": "http",
       "REDIS_ENABLE": true
     },
-    "node_args": "--max_old_space_size=2048"
+    "node_args": "--max_old_space_size=5000"
   },{
     "name"        : "api",
     "script"      : "bin/api.js",
+    "max_memory_restart": "300M",
     "env"         : {
       "NODE_PATH": "./api",
       "NODE_ENV": "production",
@@ -24,6 +26,6 @@
       "APIPROTOCOL": "http",
       "REDIS_ENABLE": true
     },
-    "node_args": "--max_old_space_size=2048"
+    "node_args": "--max_old_space_size=500"
   }]
 }


### PR DESCRIPTION
**Temporary Solution for preventing server out of memory**

Increase v8 max_old_space_size and restart server by pm2 when memory usage is over the threshold.
 