### PR TITLE
[Update] Enable print media query and print the article well

### DIFF
--- a/src/components/Html.js
+++ b/src/components/Html.js
@@ -26,7 +26,7 @@ function Html({ children, head, reduxState, styles, script }) {
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="https://www.twreporter.org/rss2.xml" />
         <link href="/asset/favicon.png"  rel="shortcut icon" />
         { _.map(styles, (style, key) => {
-          return <link async href={style} key={key} media="screen, projection" rel="stylesheet" type="text/css" charSet="UTF-8"/>
+          return <link async href={style} key={key} media="all" rel="stylesheet" type="text/css" charSet="UTF-8"/>
         }) }
         {head.title.toComponent()}
         {head.meta.toComponent()}

--- a/src/components/article/Audio.js
+++ b/src/components/article/Audio.js
@@ -261,7 +261,7 @@ class Audio extends React.Component {
 
     // render Audio with cover photo
     return (
-      <div itemScope itemType="http://schema.org/AudioObject" className={classNames(styles['audio-container'], { [styles['mobile']]: device === 'mobile' ? true : false })}>
+      <div itemScope itemType="http://schema.org/AudioObject" className={classNames(styles['audio-container'], { [styles['mobile']]: device === 'mobile' ? true : false }, 'hidden-print')}>
         <div className={styles['audio-coverphoto']} onClick={this.handleMouseClick} onMouseEnter={this.handleOnMouseOver} onMouseLeave={this.handleOnMouseOut}>
           <div className={styles['audio-img-filter']} style={ isOncePlayed ? {
             opacity: 1

--- a/src/components/article/Image.js
+++ b/src/components/article/Image.js
@@ -1,7 +1,7 @@
 /*eslint no-unused-vars: [2, { "args": "none" }]*/
 'use strict'
 import { replaceStorageUrlPrefix } from '../../utils/index'
-import classNames from 'classnames'
+import cx from 'classnames'
 import commonStyles from './Common.scss'
 import FitwidthMixin from './mixins/FitwidthMixin'
 import { getScreenType } from '../../utils/index'
@@ -54,7 +54,7 @@ class Image extends FitwidthMixin(Component) {
         <div className={styles['img-placeholder-outer']}
             style={ { ...imgStyle } }>
           <LazyLoad offset={UI_SETTING.image.loadingOffset.placeholder} height={imgStyle.height} once={true}>
-            <img src={ replaceStorageUrlPrefix(imageUrl) } className={classNames(styles['img-placeholder'])} style={imgStyle} />
+            <img src={ replaceStorageUrlPrefix(imageUrl) } className={styles['img-placeholder']} style={imgStyle} />
           </LazyLoad>
         </div>
       )
@@ -69,7 +69,7 @@ class Image extends FitwidthMixin(Component) {
           <LazyLoad offset={UI_SETTING.image.loadingOffset.image} height={imgStyle.height} once={true}>
             <img src={ replaceStorageUrlPrefix(imageObj.url) }
               style={ { ...imgStyle } }
-              className={classNames(styles['img-absolute'])}
+              className={styles['img-absolute']}
             />
           </LazyLoad>
         </figure>
@@ -123,7 +123,7 @@ class Image extends FitwidthMixin(Component) {
     if(imageDescription && isToShowDescription) {
       descriptionBox =
         <div
-          className={classNames(commonStyles['desc-text-block'], 'text-justify')}
+          className={cx(commonStyles['desc-text-block'], 'text-justify')}
           style={{ marginTop: '16px' }}
         >
           {imageDescription}
@@ -144,14 +144,17 @@ class Image extends FitwidthMixin(Component) {
     const { isPhotography } = this.context
 
     return (
-      <div ref="imageBox" className={classNames(styles['image-box'], isPhotography ? styles['photoExclu'] : null)}>
-        <div style={outerStyle}>
+      <div ref="imageBox" className={cx(styles['image-box'], isPhotography ? styles['photoExclu'] : null)}>
+        <div className="hidden-print" style={outerStyle}>
           {renderedPlaceHoderImage}
           {renderedFigure}
           <noscript dangerouslySetInnerHTML={this._getNoscript(imgUrl, imageDescription)} />
         </div>
         {descriptionBox}
         {microData}
+        <div className="visible-print">
+          <img src={imgUrl} alt={imageDescription} />
+        </div>
       </div>
     )
   }

--- a/src/components/article/Youtube.js
+++ b/src/components/article/Youtube.js
@@ -2,7 +2,7 @@
 import BlockAlignmentWrapper from './BlockAlignmentWrapper'
 import React from 'react' // eslint-disable-next-line
 import YoutubePlayer from 'react-youtube'
-import classNames from 'classnames'
+import cx from 'classnames'
 import commonStyles from './Common.scss'
 import styles from './Youtube.scss'
 
@@ -24,11 +24,11 @@ class Youtube extends React.Component {
     }
 
     return (
-      <div className={styles['youtube-container']}>
+      <div className={cx(styles['youtube-container'], 'hidden-print')}>
         <div className={styles['youtube-iframe-container']}>
           <YoutubePlayer videoId={youtubeId} />
         </div>
-        <div className={classNames(commonStyles['desc-text-block'], 'text-justify')}>{description}</div>
+        <div className={cx(commonStyles['desc-text-block'], 'text-justify')}>{description}</div>
       </div>
     )
   }

--- a/src/components/navigation/NavBar.js
+++ b/src/components/navigation/NavBar.js
@@ -93,7 +93,7 @@ class NavBar extends Component {
     const pageType = _.get(this.props, 'header.pageType', '')
     let progressBar = (pageType === ARTICLE_STYLE || pageType === REVIEW_ARTICLE_STYLE || pageType === PHOTOGRAPHY_ARTICLE_STYLE || pageType === LONGFORM_ARTICLE_STYLE) && isScrolledOver ? <HeaderProgress percent={readPercent}/> : null
     return (
-      <div style={{ height: height+'px' }}>
+      <div className="hidden-print" style={{ height: height+'px' }}>
         <div ref="headerbox" className={styles.fixTop}>
           {this._renderMenu()}
           {progressBar}

--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -529,15 +529,17 @@ class Article extends Component {
                     date={article.publishedDate}
                   />
                 </ArticleComponents.HeadingAuthor>
-                <ArticleComponents.ShareBt
-                  appId={appId}
-                  url={cUrl}
-                  title={article.title}
-                  fbIcon={fbIcon}
-                  twitterIcon={twitterIcon}
-                  lineIcon={lineIcon}
-                />
-              <FontChangeButton changeFontSize={(fontSize)=>this.changeFontSize(fontSize)} fontSize={this.state.fontSize}/>
+                <div className="hidden-print">
+                  <ArticleComponents.ShareBt
+                    appId={appId}
+                    url={cUrl}
+                    title={article.title}
+                    fbIcon={fbIcon}
+                    twitterIcon={twitterIcon}
+                    lineIcon={lineIcon}
+                  />
+                  <FontChangeButton changeFontSize={(fontSize)=>this.changeFontSize(fontSize)} fontSize={this.state.fontSize}/>
+                </div>
               </div>
 
 
@@ -566,7 +568,7 @@ class Article extends Component {
             </article>
 
             <div ref="progressEnding"
-                className={commonStyles['components']}>
+                className={cx(commonStyles['components'], 'hidden-print')}>
               <div className={cx('inner-max', commonStyles['component'])}>
                 <ArticleComponents.BottomTags
                   data={article.tags}
@@ -602,9 +604,11 @@ class Article extends Component {
             article={get(article, [ 'relateds', 1 ])}
             navigate="previous"
           />*/}
-          <Footer
-            theme={_.get(article, 'style') === PHOTOGRAPHY_ARTICLE_STYLE ? DARK : BRIGHT}
-            copyright={copyright}/>
+          <div className="hidden-print">
+            <Footer
+              theme={_.get(article, 'style') === PHOTOGRAPHY_ARTICLE_STYLE ? DARK : BRIGHT}
+              copyright={copyright}/>
+          </div>
         </div>
       </div>
     )


### PR DESCRIPTION
**[Problem Description]** <br>
Currently our article page does not support web print (網頁列印), so you may see wrong layout of printing page.

**[Solution]**

1. Change media attribute in the css script tag
2. Use bootstrap print media query
3. Do not show navbar, video, audio, related bottoms and footer component while printing.

@garfieldduck @YuCJ @hanyulo 