### PR TITLE
[Bug] Top description cannot be displayed properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+- [Bug] Top description cannot be displayed properly if the content brief has been edited
 
 ### 1.1.2
 - [Bug] Photography page is not displaying any article

--- a/src/components/topic/Cards.js
+++ b/src/components/topic/Cards.js
@@ -27,7 +27,10 @@ export default class Cards extends Component {
     const { items } = this.props
     let cardsJsx = []
     _.forEach(items, (item, index) => {
-      const description = _.get(item, 'brief.apiData.0.content.0', _.get(item, 'ogDescription'))
+      let description = _.get(item, 'brief.apiData.0.content.0', '')
+      if(description.trim().length === 0) {
+        description = _.get(item, 'ogDescription', '')
+      }
       const imgSrc = replaceStorageUrlPrefix(_.get(item, 'heroImage.image.resizedTargets.mobile.url'))
       const title = _.get(item, 'title')
       const slug = _.get(item, 'slug')


### PR DESCRIPTION
Top description cannot be displayed properly if the content brief has been edited and removed