### PR TITLE
Fix inconsistent line-heights of paragraphs containing annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+- Fix inconsistent line-heights of paragraphs containing annotations
 
 ### 2.2.0
 - Code splitting and dynamic bundle loading by webpack

--- a/src/components/article/Annotation.scss
+++ b/src/components/article/Annotation.scss
@@ -26,7 +26,7 @@ $letter-spacing: .5px;
 
   span {
     font-size: em($font-size-base);
-    line-height: 1.8;
+    line-height: $line-height-paragraph;
     letter-spacing: $letter-spacing;
     font-weight: $font-weight-normal;
   }

--- a/src/components/article/Paragraph.scss
+++ b/src/components/article/Paragraph.scss
@@ -6,7 +6,7 @@
 .paragraph {
   font-size: em($font-size-base);
   font-weight: $font-weight-normal;
-  line-height: 1.95;
+  line-height: $line-height-paragraph;
   letter-spacing: $general-letter-space;
   white-space: pre-wrap;
 }

--- a/src/themes/common-variables.scss
+++ b/src/themes/common-variables.scss
@@ -49,6 +49,7 @@ $topic-letter-space-tight: 0.1px;
 $line-height-medium: 1.4;
 $line-height-base: 1.5;
 $line-height-large: 1.8;
+$line-height-paragraph: 1.95;
 // == Margin
 // ## Components
 $component-margin-bottom: 40px;


### PR DESCRIPTION
line-height becomes 1.8 instead of 1.95 when the paragraph contains annotations