### PR TITLE
Set Cache-Control: no-store in those endpoints related to users, such  as /activate and /bookmarks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+### 2.4.4
+- Set Cache-Control: no-store in those endpoints related to users, such as /activate and /bookmarks.
+
 ### 2.4.3
 - Remove unused Layout in components
 - Apply code refactor to `withLayout`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "npm run clean && npm run build-webpack && npm run build-server",

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -11,8 +11,11 @@ function loadRoute(cb) {
   }
 }
 
+const BOOKMAKRS_PAGE_PATH = 'bookmarks'
+
 // The variable is declared for @twreporter/registration
 export const ACTIVATE_PAGE_PATH = 'activate'
+export const NO_CACHE_PAGES = [ `/${ACTIVATE_PAGE_PATH}`, `/${BOOKMAKRS_PAGE_PATH}` ]
 
 function errorLoading(err) {
   console.error('Err to load module:', err) //eslint-disable-line
@@ -127,7 +130,7 @@ export default function createRoutes(history = browserHistory) {
           }}
         />
         <Route
-          path="bookmarks(/:pageNumber)"
+          path={`${BOOKMAKRS_PAGE_PATH}(/:pageNumber)`}
           redirectPath="/signin"
           getComponent={(location, cb) => {
             Promise.all([

--- a/src/server.js
+++ b/src/server.js
@@ -11,11 +11,10 @@ import ReactDOMServer from 'react-dom/server'
 import config from '../config'
 import configureStore from './store/configureStore'
 import cookieParser from 'cookie-parser'
-import createRoutes from './routes/index'
+import createRoutes, { ACTIVATE_PAGE_PATH, NO_CACHE_PAGES } from './routes/index'
 import get from 'lodash/get'
 import http from 'http'
 import path from 'path'
-import { ACTIVATE_PAGE_PATH } from './routes/index'
 import { NotFoundError } from './custom-error'
 import { Provider } from 'react-redux'
 import { RouterContext, match, createMemoryHistory } from 'react-router'
@@ -130,7 +129,15 @@ app.get('*', async function (req, res, next) {
 
         // set Cache-Control header for caching
         if (!res.headersSent) {
-          res.header('Cache-Control', 'public, max-age=300')
+          const pathname = get(renderProps, 'location.pathname', '')
+          // set Cache-Control directive in response header
+          NO_CACHE_PAGES.forEach((noCachePage) => {
+            if (pathname.indexOf(noCachePage) > -1) {
+              res.header('Cache-Control', 'no-store')
+            } else {
+              res.header('Cache-Control', 'public, max-age=300')
+            }
+          })
         }
 
         const html = ReactDOMServer.renderToStaticMarkup(


### PR DESCRIPTION
## What changed?
Before this PR, we set `Cache-Control: public, max-age=300` in the response header,
hence, the requests will be cached in the reverse proxy like `cloudflare` and our own `nginx server`.
But after we launch the membership feature,  we can not cache those requests in order to avoid the users from getting the wrong response.

This PR will set `Cache-Control: no-store` in the response header for certain endpoints we don't want to cache, such as `/bookmarks` and `/activate`.

@YuCJ 