### PR TITLE
Turn off css source map in production and bump twreporter-react-component version to 2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fix css class missing bug
 - Add css minimize
 - Turn off css source map with webpack in production
+- Bump twreporter-react-component version to 2.0.6
 
 ### 2.4.4
 - Set Cache-Control: no-store in those endpoints related to users, such as /activate and /bookmarks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 - Fix css class missing bug
 - Add css minimize
+- Turn off css source map with webpack in production
 
 ### 2.4.4
 - Set Cache-Control: no-store in those endpoints related to users, such as /activate and /bookmarks.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/twreporter/twreporter-react/issues"
   },
   "dependencies": {
-    "@twreporter/react-components": "2.0.5",
+    "@twreporter/react-components": "2.0.6",
     "@twreporter/redux": "^3.0.0",
     "@twreporter/registration": "^2.0.2",
     "babel-plugin-system-import-transformer": "^3.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,9 +82,9 @@ const webpackConfig = {
               loader: 'css-loader',
               options: {
                 minimize: isProduction,
+                sourceMap: !isProduction,
                 importLoaders: 2,
                 modules: true,
-                sourceMap: true,
                 // Make sure this setting is equal to settings in .bablerc
                 localIdentName: '[name]__[local]___[hash:base64:5]'
               }
@@ -101,9 +101,9 @@ const webpackConfig = {
             loader: 'css-loader',
             options: {
               minimize: isProduction,
+              sourceMap: !isProduction,
               importLoaders: 2,
               modules: true,
-              sourceMap: true,
               localIdentName: '[name]__[local]___[hash:base64:5]'
             }
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@twreporter/react-components@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@twreporter/react-components/-/react-components-2.0.5.tgz#e458c2eb04a03f3a4abdfac54340e2510905e203"
+"@twreporter/react-components@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@twreporter/react-components/-/react-components-2.0.6.tgz#53fb2f8f9ff87d8c755baaf12a90bc7d1d53cc2e"
   dependencies:
     "@twreporter/velocity-react" "^1.3.4"
     lodash "^4.17.4"


### PR DESCRIPTION
- Turn off css source map with webpack in production
- Bump `twreporter-react-component` version to 2.0.6