### PR TITLE
 Bump version to 2.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+### 2.4.7
+- [Bug fix] avoid to set response header Cache-Control=public,max-age=300 in certain endpoints like /bookmarks, /activate
+
 ### 2.4.6 
 - Scroll to the target section on homepage if section parameter is existed
 - Use @twreporter/react-components@2.1.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "npm run clean && npm run build-webpack && npm run build-server",

--- a/src/server.js
+++ b/src/server.js
@@ -131,13 +131,14 @@ app.get('*', async function (req, res, next) {
         if (!res.headersSent) {
           const pathname = get(renderProps, 'location.pathname', '')
           // set Cache-Control directive in response header
-          NO_CACHE_PAGES.forEach((noCachePage) => {
+          for(const noCachePage of NO_CACHE_PAGES) {
             if (pathname.indexOf(noCachePage) > -1) {
               res.header('Cache-Control', 'no-store')
+              break
             } else {
               res.header('Cache-Control', 'public, max-age=300')
             }
-          })
+          }
         }
 
         const html = ReactDOMServer.renderToStaticMarkup(


### PR DESCRIPTION

[Bug fix] avoid to set response header Cache-Control=public,max-age=300 in certain endpoints like /bookmarks, /activate