### PR TITLE
[Minor Version] Bump version to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### Unreleased
+- Update HeadingAuthor.js. Move extendByLine to the front if it starts with `文 `
+- Show License at the end of posts 
+-  Enable pagination on tag/category listing page
 
 ### 2.5.6
 - [Bug] fix image too big problem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,30 @@
 ### Unreleased
-- Update HeadingAuthor.js. Move extendByLine to the front if it starts with `文 `
+
+### 2.6.0
+#### Minor Change
+- Update @twreporter/react-components from 2.1.12 to 3.0.1
+- Update @twreporter/registration from 2.1.5 to 3.0.0
+- Update @twreporter/redux from 3.0.0 to 4.0.1
+For being compatiable with the above dependencies updates.
+Do the following things:
+1. @twreporter/redux which drop bookmarks related stuffs
+2. Import bookmarks related statement (mainly redux actions/reducers) from @twreporter/registration
+3. Move Functional Bookmark Icons (add/Remove) back to @twreporter/registration
+4. Import bookmark frame from @twreporter/registration rather than react-components
+5. Create widget service provider from @twreporter/registration
+6. Move auth process from client.js to App.js (server/client side redux store render conflict)
+
+#### Features
+- Enable pagination on tag/category listing page
 - Show License at the end of posts 
--  Enable pagination on tag/category listing page
-- Be compatiable with refactored @twreporter/registration package
-- Include client.js and Server.js
-- Be compatible with @twreporter/redux which drop bookmarks related stuffs
-- Import bookmarks related statement (mainly redux actions/reducers) from @twreporter/registration
-- Move Functional Bookmark Icons (add/Remove) back to @twreporter/registration.
-- Remove BundleAnalyzerPlugin (webpack config.js)
-- Import bookmark frame from @twreporter/registration rather than react-components.
-- Create widget service provider from @twreporter/registration
-- Move auth process from client.js to App.js (server/client side redux store render conflict)
+- Standalone widgets for signin/signout and bookmark, endpoints are
+  - /widgets-services
+  - /widgets-bookmark-desktop
+  - /widgets-bookmark-mobile
+
+#### Patches
+- Update HeadingAuthor.js. Move extendByLine to the front if it starts with `文 `
+- Add more padding on Topic listing page
 
 ### 2.5.6
 - [Bug] fix image too big problem

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@twreporter/react-components": "2.1.12",
     "@twreporter/react-flex-carousel": "^1.1.1",
-    "@twreporter/redux": "4.0.1",
+    "@twreporter/redux": "4.0.0",
     "@twreporter/registration": "^2.1.5",
     "babel-plugin-inline-react-svg": "^0.4.0",
     "babel-plugin-system-import-transformer": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@twreporter/react-components": "2.1.12",
     "@twreporter/react-flex-carousel": "^1.1.1",
-    "@twreporter/redux": "^3.0.0",
+    "@twreporter/redux": "4.0.1",
     "@twreporter/registration": "^2.1.5",
     "babel-plugin-inline-react-svg": "^0.4.0",
     "babel-plugin-system-import-transformer": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "2.5.6",
+  "version": "2.6.0",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "npm run clean && npm run build-webpack && npm run build-server",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "url": "https://github.com/twreporter/twreporter-react/issues"
   },
   "dependencies": {
-    "@twreporter/react-components": "2.1.12",
+    "@twreporter/react-components": "^3.0.1",
     "@twreporter/react-flex-carousel": "^1.1.1",
-    "@twreporter/redux": "4.0.0",
-    "@twreporter/registration": "^2.1.5",
+    "@twreporter/redux": "4.0.1",
+    "@twreporter/registration": "2.2.0",
     "babel-plugin-inline-react-svg": "^0.4.0",
     "babel-plugin-system-import-transformer": "^3.1.0",
     "classnames": "^2.2.1",

--- a/src/components/article/HeadingAuthor.js
+++ b/src/components/article/HeadingAuthor.js
@@ -47,10 +47,25 @@ export const HeadingAuthor = ({ authors, children, extendByline }) => {
     )
   })
 
+  // Handle text starting with `文 `, such as `文 陳貞樺` in the extendByLine,
+  // which is a free text field.
+  // Move it to the front and bolden `文 ` text.
+  const escapeWord = '文 '
+  if (typeof extendByline === 'string' && extendByline.startsWith(escapeWord)) {
+    const _byline = extendByline.replace(escapeWord, '')
+    authorRows.unshift(
+      <div key="byline" className={classNames(styles['author-item'])}>
+        <span>文</span>
+        <span itemProp="author">{_byline}</span>
+      </div>
+    )
+  } else {
+    authorRows.push(<span key="extend_by_line" itemProp="author" style={{ paddingRight: '8px' }}>{extendByline}</span>)
+  }
+
   return (
     <div className={styles['author-container']}>
       { authorRows }
-      <span itemProp="author" style={{ paddingRight: '8px' }}>{extendByline}</span>
       { children }
     </div>
   )

--- a/src/components/article/zoom-in-leading-image.js
+++ b/src/components/article/zoom-in-leading-image.js
@@ -1,5 +1,5 @@
 import FadeText from '@twreporter/react-components/lib/fade-text'
-import HeaderComposite from '@twreporter/react-components/lib/header'
+import Header from '@twreporter/react-components/lib/header'
 import PropTypes from 'prop-types'
 import React from 'react'
 import TitleRowUpon from './title-row-upon'
@@ -13,7 +13,6 @@ import { camelizeKeys } from 'humps'
 import { screen } from '../../themes/screen'
 
 
-const { Header } = HeaderComposite
 const { childAnimationStoper, unlockAfterAnimation } = FadeText.scrollManager
 const topNavbarHeight = 151
 

--- a/src/components/shared/License.js
+++ b/src/components/shared/License.js
@@ -34,7 +34,7 @@ export default class License extends React.PureComponent {
     const year = this._extractYear(publishedDate)
     let licenseJSX = ''
 
-    if (license.toLowerCase() === 'copyrighted') {
+    if (typeof license === 'string' && license.toLowerCase() === 'copyrighted') {
       licenseJSX = <Text>© { year } All rights Reserved</Text>
     } else {
       licenseJSX = <Text>本文依 CC 創用姓名標示-非商業性-禁止改作3.0台灣授權條款釋出</Text>

--- a/src/components/shared/License.js
+++ b/src/components/shared/License.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+import { colors, lineHeight, typography } from '../../themes/common-variables'
+
+const Text = styled.p`
+  color: ${colors.gray.gray50};
+  font-size: ${typography.font.size.medium};
+  line-height: ${lineHeight.lineHeightBase};
+`
+
+const Container = styled.div`
+  text-align: center;
+  padding: 15px 24px 15px 24px;
+`
+
+export default class License extends React.PureComponent {
+
+  static defaultProps = {
+    publishedDate: ''
+  }
+  static propTypes = {
+    license: PropTypes.string.isRequired,
+    publishedDate: PropTypes.string
+  }
+
+  _extractYear(publishedDate) {
+    const date = publishedDate ? new Date(publishedDate) : new Date()
+    return date.getFullYear()
+  }
+
+  render() {
+    const { license, publishedDate } = this.props
+    const year = this._extractYear(publishedDate)
+    let licenseJSX = ''
+
+    if (license.toLowerCase() === 'copyrighted') {
+      licenseJSX = <Text>© { year } All rights Reserved</Text>
+    } else {
+      licenseJSX = <Text>本文依 CC 創用姓名標示-非商業性-禁止改作3.0台灣授權條款釋出</Text>
+    }
+
+    return (
+      <Container>
+        {licenseJSX}
+      </Container>
+    )
+  }
+}
+

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -5,7 +5,7 @@ import ErrorBoundary from '../components/ErrorBoundary'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { setupTokenInLocalStorage, deletAuthInfoAction, authUserByTokenAction, localStorageKeys, renewToken, getItem, scheduleRenewToken, signOutAction } from '@twreporter/registration'
-import HeaderComposite from '@twreporter/react-components/lib/header'
+import { AuthenticationContext } from '@twreporter/react-components/lib/header'
 
 // lodash
 import get from 'lodash/get'
@@ -13,8 +13,6 @@ import get from 'lodash/get'
 const _ = {
   get
 }
-
-const { AuthenticationContext } = HeaderComposite
 
 class App extends PureComponent {
   constructor(props) {

--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -4,7 +4,7 @@
 import * as ArticleComponents from '../components/article/index'
 import ArticleMeta from '../components/article/article-meta'
 import ArticleTools from './ArticleTools'
-import HeaderComposite from '@twreporter/react-components/lib/header'
+import Header from '@twreporter/react-components/lib/header'
 import Helmet from 'react-helmet'
 import LeadingVideo from '../components/shared/LeadingVideo'
 import License from '../components/shared/License'
@@ -54,7 +54,6 @@ const _ = {
   sortBy
 }
 
-const { Header } = HeaderComposite
 const { actions, reduxStateFields, utils } = twreporterRedux
 const { fetchAFullPost } = actions
 

--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -7,6 +7,7 @@ import ArticleTools from './ArticleTools'
 import Header from '@twreporter/react-components/lib/header'
 import Helmet from 'react-helmet'
 import LeadingVideo from '../components/shared/LeadingVideo'
+import License from '../components/shared/License'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import ReadingProgress from '../components/article/ReadingProgress'
@@ -400,6 +401,9 @@ class Article extends PureComponent {
       titleFontColor: titleColor,
       subtitleFontColor: subTitleColor
     }
+
+    const license = _.get(article, 'copyright', 'Creative-Commons')
+
     return (
       <div>
         <Helmet
@@ -530,6 +534,7 @@ class Article extends PureComponent {
                 />
               </article>
             </Content>
+            <License license={license} publishedDate={article.publishedDate}/>
             <div ref={div => {this.progressEnding = div}}
                 className={cx(commonStyles['components'], 'hidden-print', styles['padding-patch'])}>
               <div className={cx('inner-max', commonStyles['component'])}>

--- a/src/containers/Category.js
+++ b/src/containers/Category.js
@@ -1,5 +1,5 @@
 import Helmet from 'react-helmet'
-import More from '../components/More'
+import Pagination from '../components/Pagination'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import SystemError from '../components/SystemError'
@@ -20,10 +20,6 @@ const _  = {
 const { actions, reduxStateFields, utils } = twreporterRedux
 const { fetchListedPosts } = actions
 
-if (process.env.BROWSER) {
-  require('./Category.css')
-}
-
 const MAXRESULT = 10
 const categories = 'categories'
 
@@ -33,59 +29,53 @@ function getListID(paramCategory) {
 }
 
 class Category extends Component {
-  static fetchData({ params, store }) {
-    return store.dispatch(fetchListedPosts(getListID(params.category), categories, MAXRESULT))
-  }
-
-  constructor(props) {
-    super(props)
-    const category = this.props.params.category
-    this.state = {
-      catId: getListID(category)
+  // params are passed from Route component of react-router
+  static fetchData({ params, store, query }) {
+    /* fetch page 1 if page is invalid */
+    let page = parseInt(_.get(query, 'page', 1), 10)
+    if (isNaN(page) || page < 0) {
+      page = 1
     }
-    this.loadMore = this._loadMore.bind(this)
+    return store.dispatch(fetchListedPosts(getListID(params.category), categories, MAXRESULT, page))
   }
 
   componentWillMount() {
-    const { lists, fetchListedPosts } = this.props
+    const { fetchListedPosts, catId } = this.props
+    const page = _.get(this.props, 'page', 1)
 
-    let catId = this.state.catId
-
-    // if fetched before, do nothing
-    if (_.get(lists, [ catId, 'items', 'length' ], 0) > 0) {
-      return
-    }
-
-    fetchListedPosts(catId, categories, MAXRESULT)
-
+    fetchListedPosts(catId, categories, MAXRESULT, page)
   }
 
   componentWillReceiveProps(nextProps) {
-    const { lists, fetchListedPosts, params } = nextProps
-    let catId = getListID(params.category)
+    const { fetchListedPosts, catId } = nextProps
+    const page = _.get(nextProps, 'page', 1)
 
-    // if fetched before, do nothing
-    if (_.get(lists, [ catId, 'items', 'length' ], 0) > 0) {
-      return
-    }
-
-    fetchListedPosts(catId, categories, MAXRESULT)
-  }
-
-  _loadMore() {
-    const { fetchListedPosts, params } = this.props
-    let catId = getListID(params.category)
-    fetchListedPosts(catId, categories, MAXRESULT)
+    fetchListedPosts(catId, categories, MAXRESULT, page)
   }
 
   render() {
-    const { lists, entities, params } = this.props
-    const category = _.get(params, 'category', '')
+    const { lists, entities, catId, category, page, pathname } = this.props
     const postEntities = _.get(entities, reduxStateFields.postsInEntities, {})
-    const catId = getListID(category)
     const error = _.get(lists, [ catId, 'error' ], null)
+
+    // total items will be in that catId
     const total = _.get(lists, [ catId, 'total' ], 0)
-    const posts = utils.denormalizePosts(_.get(lists, [ catId, 'items' ], []), postEntities)
+
+    // pages will be like
+    // {
+    //   1: [0, 9],
+    //   3: [10, 19],
+    // }
+    //
+    // which means the items of page 1 are in items[0] to items[9],
+    // the items of page 3 are in items[10] to item [19]
+    const pages = _.get(lists, [ catId, 'pages' ], {})
+    const startPos = _.get(pages, [ page, 0 ], 0)
+    const endPos = _.get(pages, [ page, 1 ], 0)
+    // denormalize the items of current page
+    const posts = utils.denormalizePosts(_.get(lists, [ catId, 'items' ], []).slice(startPos, endPos + 1), postEntities)
+
+    const totalPages = total / MAXRESULT
     const postsLen = _.get(posts, 'length', 0)
     let isFetching = false
 
@@ -101,12 +91,6 @@ class Category extends Component {
     const catName = categoryString[camelize(category)]
     const title = catName + SITE_NAME.SEPARATOR + SITE_NAME.FULL
     const canonical = `${SITE_META.URL}category/${category}`
-
-    const MoreJSX = total > posts.length ? (
-      <More loadMore={this.loadMore}>
-        <span style={{ color: error ? 'red' : 'white' }}>{error ? '更多文章（請重試）' : '更多文章'}</span>
-      </More>
-    ) : null
 
     return (
       <div>
@@ -132,27 +116,46 @@ class Category extends Component {
           catName={catName}
           isFetching={isFetching}
         />
-        {MoreJSX}
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          pathname={pathname}
+        />
       </div>
     )
   }
 }
 
-function mapStateToProps(state) {
+function mapStateToProps(state, props) {
+  const location = _.get(props, 'location')
+  const params = _.get(props, 'params')
+  const page = parseInt(_.get(location, 'query.page', 1), 10)
+  const category = _.get(params, 'category')
+  const catId = getListID(category)
+  const pathname = _.get(location, 'pathname', `/categories/${category}`)
   return {
     lists: state[reduxStateFields.lists],
-    entities: state[reduxStateFields.entities]
+    entities: state[reduxStateFields.entities],
+    catId,
+    category,
+    page,
+    pathname
   }
 }
 
 Category.defaultProps = {
   entities: {},
-  lists: {}
+  lists: {},
+  catId: ''
 }
 
 Category.propTypes = {
   entities: PropTypes.object,
-  lists: PropTypes.object
+  lists: PropTypes.object,
+  catId: PropTypes.string,
+  category: PropTypes.string.isRequired,
+  page: PropTypes.number.isRequired,
+  pathname: PropTypes.string.isRequired
 }
 
 export { Category }

--- a/src/containers/Category.js
+++ b/src/containers/Category.js
@@ -75,7 +75,7 @@ class Category extends Component {
     // denormalize the items of current page
     const posts = utils.denormalizePosts(_.get(lists, [ catId, 'items' ], []).slice(startPos, endPos + 1), postEntities)
 
-    const totalPages = total / MAXRESULT
+    const totalPages = Math.ceil(total / MAXRESULT)
     const postsLen = _.get(posts, 'length', 0)
     let isFetching = false
 

--- a/src/containers/Tag.js
+++ b/src/containers/Tag.js
@@ -80,7 +80,7 @@ class Tag extends Component {
     // denormalize the items of current page
     const posts = utils.denormalizePosts(_.get(lists, [ tagId, 'items' ], []).slice(startPos, endPos + 1), postEntities)
 
-    const totalPages = total / MAXRESULT
+    const totalPages = Math.ceil(total / MAXRESULT)
     const postsLen = _.get(posts, 'length', 0)
     let isFetching = false
 

--- a/src/containers/Tag.js
+++ b/src/containers/Tag.js
@@ -1,5 +1,5 @@
 import Helmet from 'react-helmet'
-import More from '../components/More'
+import Pagination from '../components/Pagination'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import SystemError from '../components/SystemError'
@@ -21,42 +21,28 @@ const MAXRESULT = 10
 const tags = 'tags'
 
 class Tag extends Component {
-  static fetchData({ params, store }) {
-    return store.dispatch(fetchListedPosts(params.tagId, tags, MAXRESULT))
-  }
-
-  constructor(props) {
-    super(props)
-    this.loadMore = this._loadMore.bind(this)
+  // params are passed from Route component of react-router
+  static fetchData({ params, store, query }) {
+    /* fetch page 1 if page is invalid */
+    let page = parseInt(_.get(query, 'page', 1), 10)
+    if (isNaN(page) || page < 0) {
+      page = 1
+    }
+    return store.dispatch(fetchListedPosts(params.tagId, tags, MAXRESULT, page))
   }
 
   componentWillMount() {
-    const { fetchListedPosts, lists, params } = this.props
+    const { fetchListedPosts, tagId } = this.props
+    const page = _.get(this.props, 'page', 1)
 
-    let tagId = _.get(params, 'tagId')
-
-    if (_.get(lists, [ tagId, 'items', 'length' ], 0) > 0) {
-      return
-    }
-
-    fetchListedPosts(tagId, tags, MAXRESULT)
+    fetchListedPosts(tagId, tags, MAXRESULT, page)
   }
 
   componentWillReceiveProps(nextProps) {
-    const { fetchListedPosts, lists, params } = nextProps
-    let tagId = _.get(params, 'tagId')
+    const { fetchListedPosts, tagId } = nextProps
+    const page = _.get(nextProps, 'page', 1)
 
-    if (_.get(lists, [ tagId, 'items', 'length' ], 0) > 0) {
-      return
-    }
-
-    fetchListedPosts(tagId, tags, MAXRESULT)
-  }
-
-  _loadMore() {
-    const { fetchListedPosts, params } = this.props
-    const tagId = _.get(params, 'tagId')
-    fetchListedPosts(tagId, tags, MAXRESULT)
+    fetchListedPosts(tagId, tags, MAXRESULT, page)
   }
 
   _findTagName(tags, tagId) {
@@ -73,12 +59,28 @@ class Tag extends Component {
   }
 
   render() {
-    const { lists, entities, params } = this.props
+    const { lists, entities, page, pathname, tagId } = this.props
     const postEntities = _.get(entities, reduxStateFields.postsInEntities, {})
-    const tagId = _.get(params, 'tagId')
     const error = _.get(lists, [ tagId, 'error' ], null)
+
+    // total items will be in that tagId
     const total = _.get(lists, [ tagId, 'total' ], 0)
-    const posts = utils.denormalizePosts(_.get(lists, [ tagId, 'items' ], []), postEntities)
+
+    // pages will be like
+    // {
+    //   1: [0, 9],
+    //   3: [10, 19],
+    // }
+    //
+    // which means the items of page 1 are in items[0] to items[9],
+    // the items of page 3 are in items[10] to item [19]
+    const pages = _.get(lists, [ tagId, 'pages' ], {})
+    const startPos = _.get(pages, [ page, 0 ], 0)
+    const endPos = _.get(pages, [ page, 1 ], 0)
+    // denormalize the items of current page
+    const posts = utils.denormalizePosts(_.get(lists, [ tagId, 'items' ], []).slice(startPos, endPos + 1), postEntities)
+
+    const totalPages = total / MAXRESULT
     const postsLen = _.get(posts, 'length', 0)
     let isFetching = false
 
@@ -94,12 +96,6 @@ class Tag extends Component {
     const tagName = this._findTagName(_.get(posts, [ 0, 'tags' ]), tagId)
     const canonical = `${SITE_META.URL}tag/${tagId}`
     const title = tagName + SITE_NAME.SEPARATOR + SITE_NAME.FULL
-
-    const MoreJSX = total > postsLen ? (
-      <More loadMore={this.loadMore}>
-        <span style={{ color: error ? 'red' : 'white' }}>{error ? '更多文章（請重試）' : '更多文章'}</span>
-      </More>
-    ) : null
 
     return (
       <div>
@@ -125,16 +121,28 @@ class Tag extends Component {
           tagName={tagName}
           isFetching={isFetching}
         />
-        {MoreJSX}
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          pathname={pathname}
+        />
       </div>
     )
   }
 }
 
-function mapStateToProps(state) {
+function mapStateToProps(state, props) {
+  const location = _.get(props, 'location')
+  const params = _.get(props, 'params')
+  const page = parseInt(_.get(location, 'query.page', 1), 10)
+  const tagId = _.get(params, 'tagId', '')
+  const pathname = _.get(location, 'pathname', `/tag/${tagId}`)
   return {
     lists: state[reduxStateFields.lists],
-    entities: state[reduxStateFields.entities]
+    entities: state[reduxStateFields.entities],
+    page,
+    pathname,
+    tagId
   }
 }
 
@@ -145,7 +153,10 @@ Tag.defaultProps = {
 
 Tag.propTypes = {
   lists: PropTypes.object,
-  entities: PropTypes.object
+  entities: PropTypes.object,
+  tagId: PropTypes.string.isRequired,
+  page: PropTypes.number.isRequired,
+  pathname: PropTypes.string.isRequired
 }
 
 export { Tag }

--- a/src/containers/Topics.js
+++ b/src/containers/Topics.js
@@ -33,7 +33,7 @@ const PageContainer = styled.div`
   position: relative;
   min-height: 100vh;
   width: 100%;
-  padding: 30px 0 0 0;
+  padding: 30px 24px 0 24px;
 `
 
 class Topics extends Component {

--- a/src/helpers/with-layout.js
+++ b/src/helpers/with-layout.js
@@ -2,10 +2,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'
 import Footer from '@twreporter/react-components/lib/footer'
-import HeaderComposite from '@twreporter/react-components/lib/header'
+import Header from '@twreporter/react-components/lib/header'
 import { layout } from '../themes/common-variables'
-
-const { Header } = HeaderComposite
 
 const STYLE_VARIABLES = {
   BG_COLOR: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -200,6 +200,7 @@ if (isProduction) {
       allChunks: true
     }),
     new webpack.optimize.UglifyJsPlugin()
+    //   new BundleAnalyzerPlugin()
   )
 } else {
   webpackConfig.plugins.push(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     ps-tree "^1.1.0"
 
-"@twreporter/react-components@2.1.12":
-  version "2.1.12"
-  resolved "https://registry.yarnpkg.com/@twreporter/react-components/-/react-components-2.1.12.tgz#505d3f5b68a5d751a3633aa526a51edd353e0e63"
+"@twreporter/react-components@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@twreporter/react-components/-/react-components-3.0.1.tgz#7f7a255960d003fc09c8b4d3d0fa8b2e2e4e5a68"
   dependencies:
     "@twreporter/velocity-react" "^1.4.1"
     lodash "^4.17.4"
@@ -26,18 +26,18 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@twreporter/react-flex-carousel/-/react-flex-carousel-1.1.1.tgz#36f36d2e3d31f95a8961e420a6e837608d064f2e"
 
-"@twreporter/redux@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@twreporter/redux/-/redux-3.0.0.tgz#c3d76c3ca98bb3603f33ce4cd22a1bfd8ae116fc"
+"@twreporter/redux@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@twreporter/redux/-/redux-4.0.1.tgz#2895e525d8292b8a500875feb929feb3fe18d97a"
   dependencies:
     axios "^0.16.1"
     es6-error "^4.0.2"
     lodash "^4.17.4"
     redux "^3.6.0"
 
-"@twreporter/registration@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@twreporter/registration/-/registration-2.1.5.tgz#6c24bb8d9cb2348a768ac4ac8b947bb3f50ab4dd"
+"@twreporter/registration@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@twreporter/registration/-/registration-2.2.0.tgz#ea20e98a3bb6fd2845b23a0b6f3415297618f6ee"
   dependencies:
     axios "^0.16.2"
     lodash "^4.17.4"


### PR DESCRIPTION
#### Minor Change
- Update @twreporter/react-components from 2.1.12 to 3.0.1
- Update @twreporter/registration from 2.1.5 to 3.0.0
- Update @twreporter/redux from 3.0.0 to 4.0.1
For being compatiable with the above dependencies updates.
Do the following things:
1. @twreporter/redux which drop bookmarks related stuffs
2. Import bookmarks related statement (mainly redux actions/reducers) from @twreporter/registration
3. Move Functional Bookmark Icons (add/Remove) back to @twreporter/registration
4. Import bookmark frame from @twreporter/registration rather than react-components
5. Create widget service provider from @twreporter/registration
6. Move auth process from client.js to App.js (server/client side redux store render conflict)

#### Features
- Enable pagination on tag/category listing page (see this reference [PR](https://github.com/twreporter/twreporter-redux/pull/19))
- Show License at the end of posts
- Standalone widgets for signin/signout and bookmark, endpoints are
  - /widgets-services
  - /widgets-bookmark-desktop
  - /widgets-bookmark-mobile

#### Patches
- Update HeadingAuthor.js. Move extendByLine to the front if it starts with `文 `
- Add more padding on Topic listing page