### PR TITLE
Update @twreporter/react-components package version from 4.0.3 to 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+### 2.7.2
+**Update @twreporter/react-components package version from 4.0.3 to 4.0.4**
+- Add `srcSet` and `sizes` to `img-wrapper.js` so that images of different sizes on index-page will be rendered on resolution demand.
+
 ### 2.7.1
 #### Bugs Fixed
 - Bookmarks listing page can not show bookmarks

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/twreporter/twreporter-react/issues"
   },
   "dependencies": {
-    "@twreporter/react-components": "^4.0.3",
+    "@twreporter/react-components": "^4.0.4",
     "@twreporter/react-flex-carousel": "^1.1.1",
     "@twreporter/redux": "4.0.2",
     "@twreporter/registration": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     ps-tree "^1.1.0"
 
-"@twreporter/react-components@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@twreporter/react-components/-/react-components-4.0.3.tgz#747198ea81cc28bfeb84c32285d42e4abc97d210"
+"@twreporter/react-components@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@twreporter/react-components/-/react-components-4.0.4.tgz#a4ffedd9cb834b46b3bf75c1f9c36c9d3b59540c"
   dependencies:
     "@twreporter/velocity-react" "^1.4.1"
     hoist-non-react-statics "^2.3.1"


### PR DESCRIPTION
Add `srcSet` and `sizes` to `img-wrapper.js` so that images of different sizes on index-page will be rendered on resolution demand.
