### PR TITLE
Adds some space between channel bar and title in article page on tablet

### DIFF
--- a/src/components/article/layout/title-row-above.js
+++ b/src/components/article/layout/title-row-above.js
@@ -32,6 +32,7 @@ const Container = styled.div`
     width: ${layout.desktop.width.small}px;
   `}
   ${screen.tablet`
+    margin: 24px auto;
     width: ${layout.tablet.width.small}px;
   `}
   ${screen.mobile`


### PR DESCRIPTION
This patch adds margin space between channel bar and title on tablet. The new added margin-top value equals to the margin-bottom value of title.