### PR TITLE
Bug fix and service worker boilerplate improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### Unreleased
+### 3.0.2
+-  Improve the service worker boilerplate. Update src/client.js 
+- [Bug] Fix venngage infographic vendor not rendering iframe
+
 ### 3.0.1
 - [HotFix] Update src/containers/App.js. Fix typo.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",

--- a/service-worker/service-worker.tmpl
+++ b/service-worker/service-worker.tmpl
@@ -7,6 +7,10 @@ var <%- functionName %> = <%= externalFunctions[functionName] %>;
 
 self.addEventListener('install', function(e) {
   console.log('[ServiceWorker] Install');
+
+  //  forces the waiting service worker to become the active service worker.
+  self.skipWaiting()
+
   e.waitUntil(
     caches.open(cacheName).then(function(cache) {
       console.log('[ServiceWorker] Caching app shell');

--- a/src/client.js
+++ b/src/client.js
@@ -49,16 +49,66 @@ configureStore(browserHistory, reduxState)
     })
   })
 
-// Setup service worker if browser supports
-if('serviceWorker' in navigator && !__DEVELOPMENT__) {
-  // register service worker
-  navigator.serviceWorker.register('/sw.js').then(function (registration) {
-    // Registration was successful
-    console.log('ServiceWorker registration successful with scope: ', registration.scope)
-  }, function (err) {
-    // registration failed :(
-    console.log('ServiceWorker registration failed: ', err)
+
+/**
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env browser */
+'use strict'
+
+if ('serviceWorker' in navigator && !__DEVELOPMENT__) {
+  // Delay registration until after the page has loaded, to ensure that our
+  // precaching requests don't degrade the first visit experience.
+  // See https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration
+  window.addEventListener('load', function () {
+    // Your service-worker.js *must* be located at the top-level directory relative to your site.
+    // It won't be able to control pages unless it's located at the same level or higher than them.
+    // *Don't* register service worker file in, e.g., a scripts/ sub-directory!
+    // See https://github.com/slightlyoff/ServiceWorker/issues/468
+    navigator.serviceWorker.register('/sw.js').then(function (reg) {
+      // updatefound is fired if service-worker.js changes.
+      reg.onupdatefound = function () {
+        // The updatefound event implies that reg.installing is set; see
+        // https://w3c.github.io/ServiceWorker/#service-worker-registration-updatefound-event
+        const installingWorker = reg.installing
+
+        installingWorker.onstatechange = function () {
+          switch (installingWorker.state) {
+            case 'installed':
+              if (navigator.serviceWorker.controller) {
+                // At this point, the old content will have been purged and the fresh content will
+                // have been added to the cache.
+                // It's the perfect time to display a "New content is available; please refresh."
+                // message in the page's interface.
+                console.log('New or updated content is available.')
+              } else {
+                // At this point, everything has been precached.
+                // It's the perfect time to display a "Content is cached for offline use." message.
+                console.log('Content is now available offline!')
+              }
+              break
+
+            case 'redundant':
+              console.error('The installing service worker became redundant.')
+              break
+          }
+        }
+      }
+    }).catch(function (e) {
+      console.error('Error during service worker registration:', e)
+    })
   })
-} else {
-  console.log('Service worker is not registered.')
 }

--- a/src/components/article/Embedded.js
+++ b/src/components/article/Embedded.js
@@ -26,7 +26,7 @@ export class EmbeddedCode extends React.Component {
    * Pick attributes that start with data and return them with a new object.
    * Example: ({ dataWidth: 100, dataPicId: 'xn3K8s' }) => ({ width: 100, picId: 'xn3K8s' })
    * Ref: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset
-   * 
+   *
    * @param {Object} attributes attributes object with camelcased keys
    * @returns {Object} dataset object
    * @memberof EmbeddedCode
@@ -44,6 +44,15 @@ export class EmbeddedCode extends React.Component {
   }
 
   componentDidMount() {
+    // workaround for rendering venngage embedded infographics
+    // In the script(https://infograph.venngage.com/js/embed/v1/embed.js) venngage provided,
+    // it addEventListener on 'load' event.
+    // After 'load' event emits, it renders the iframe.
+    // Hence, we emit the 'load' event after the script downloaded and executed.
+    const onLoad = function () {
+      const event = new Event('load')
+      window.dispatchEvent(event)
+    }
     const node = this.embedded
     const scripts = _.get(this.props, [ 'content', 0, 'scripts' ])
     if (node && Array.isArray(scripts)) {
@@ -53,6 +62,7 @@ export class EmbeddedCode extends React.Component {
         const dataset = this._pickDatasetFromAttribs(attribs)
         _.merge(scriptEle, attribs, { dataset })
         scriptEle.text = script.text || ''
+        scriptEle.onload = onLoad
         node.appendChild(scriptEle)
       })
     }


### PR DESCRIPTION
### Bug Description
Since we adopted service worker, `embed.js` of `venngage` works abnormally.
It won't generate the iframe even if we actually render the 
```
// script attributes are given by venngage
<script 
async="true"
src="https://infograph.venngage.com/js/embed/v1/embed.js" 
data-vg-id="KTf59BxqBAA" 
data-title="sexual_assault"
data-w="700"
data-h="525" 
data-multipage="true"
data-f="false">
</script>
```

### Details 
Because service worker caches the import resources, such as stylesheets and js bundles, window dispatch `load` event early than the time venngage script downloaded and executed. 
And in venngage script(https://infograph.venngage.com/js/embed/v1/embed.js), the script generates the `iframe` by listening to `load` event of `window`.
Therefore,  venngage script won't generate the `iframe`.

### Solution
We use a workaround to solve this problem.
The solution is adding a callback function, which dispatches `load` event,  after venngage script loaded.

@taylrj @YuCJ 