### PR TITLE
 [Bug]Adjust window height of pop-up-panel dynamically on about-us page

### DIFF
--- a/src/components/about-us/section-04/index.js
+++ b/src/components/about-us/section-04/index.js
@@ -198,7 +198,7 @@ const LogoContent = styled.div`
       padding-bottom: 19px;
     }
   `}
-  ${screen.desktop`
+  ${screen.desktop`    
     h3{
       font-size: 18px;
       letter-spacing: 0.4px;
@@ -208,17 +208,24 @@ const LogoContent = styled.div`
       padding-bottom: 14px; 
     }
   `}
+  ${screen.tabletBelow`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+  `}
   ${screen.tablet`
+    min-height: 144px;
     h3{
       font-size: 24px;
       letter-spacing: 0.5px;
-      margin-top: 20px;
     }    
     img{
       padding-bottom: 19px;
     }
   `}
   ${screen.mobile`
+    min-height: 124px;
     img{
       width: 64px;
       border-bottom: none;
@@ -226,7 +233,6 @@ const LogoContent = styled.div`
     h3{
       font-size: 18px;
       letter-spacing: 0.6px;
-      margin-top: 17px;
     }
     p{
       font-size: 13px;
@@ -314,8 +320,10 @@ export default class Section4 extends PureComponent {
           >
             <LogoContent>
               <img src={replaceStorageUrlPrefix(data.logo)} />
-              <h3>{data.name.english}</h3>
-              <p>{data.name.chinese}</p>
+              <div>
+                <h3>{data.name.english}</h3>
+                <p>{data.name.chinese}</p>
+              </div>
             </LogoContent>
           </LogoBlockOnTabletAbove>
         </React.Fragment>

--- a/src/components/about-us/utils/pop-up-panel.js
+++ b/src/components/about-us/utils/pop-up-panel.js
@@ -1,9 +1,14 @@
 import { screen } from './screen'
+import debounce from 'lodash/debounce'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 
 const defaultZIndex = 2
+
+const _ = {
+  debounce
+}
 
 const Panel = styled.div`
   z-index: calc(${defaultZIndex} + 1);
@@ -37,9 +42,14 @@ class PopUpBox extends React.PureComponent {
     this.handlePreventTouchstartWhenPanning = this._handlePreventTouchstartWhenPanning.bind(this)
     this.handlePreventTouchendWhenPanning = this._handlePreventTouchendWhenPanning.bind(this)
     this.handlePreventTouchmoveWhenPanning = this._handlePreventTouchmoveWhenPanning.bind(this)
+    // handle window resize
+    this._handleWindowHeight = this._handleWindowHeight.bind(this)
+    this.getDebouncedHeight = _.debounce(() => { this._handleWindowHeight() }, 100, { maxWait: 300 })
   }
 
   componentDidMount() {
+    this._handleWindowHeight()
+    window.addEventListener('resize', this.getDebouncedHeight)
     window.document.body.addEventListener('touchstart', this.handlePreventTouchstartWhenPanning, {
       passive: false
     })
@@ -62,6 +72,7 @@ class PopUpBox extends React.PureComponent {
     window.document.body.removeEventListener('touchmove', this.handlePreventTouchmoveWhenPanning, {
       passive: false
     })
+    window.removeEventListener('resize', this.getDebouncedHeight)
   }
 
   _handlePreventTouchstartWhenPanning(event) {
@@ -76,6 +87,10 @@ class PopUpBox extends React.PureComponent {
     event.preventDefault()
     this.panel.scrollTop = this.panel.scrollTop + (this.startY - event.changedTouches[0].screenY)
     this.startY = event.changedTouches[0].screenY
+  }
+
+  _handleWindowHeight() {
+    this.panel.style.height = window.innerHeight
   }
 
   render() {

--- a/src/components/about-us/utils/pop-up-panel.js
+++ b/src/components/about-us/utils/pop-up-panel.js
@@ -75,7 +75,7 @@ class PopUpBox extends React.PureComponent {
   _handlePreventTouchmoveWhenPanning = (event) => {
     event.preventDefault()
     this.panel.scrollTop = this.panel.scrollTop + (this.startY - event.changedTouches[0].screenY)
-    this.startY = event.touches[0].screenY
+    this.startY = event.changedTouches[0].screenY
   }
 
   render() {


### PR DESCRIPTION
This patch adds an event listener for the `onResize` event to change window height when the URL bar is collapsed. This situation was found in chrome browser of android devices.