### PR TITLE
Update React-Loadable and EmbeddedCode

### DIFF
--- a/src/components/article/Embedded.js
+++ b/src/components/article/Embedded.js
@@ -17,11 +17,16 @@ const _ = {
   merge
 }
 
-export class EmbeddedCode extends React.Component {
+function emitLoadEvent() {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('load'))
+  }
+}
+
+export class EmbeddedCode extends React.PureComponent {
   constructor(props) {
     super(props)
   }
-
   /**
    * Pick attributes that start with data and return them with a new object.
    * Example: ({ dataWidth: 100, dataPicId: 'xn3K8s' }) => ({ width: 100, picId: 'xn3K8s' })
@@ -43,16 +48,13 @@ export class EmbeddedCode extends React.Component {
     return dataset
   }
 
+
   componentDidMount() {
     // workaround for rendering venngage embedded infographics
     // In the script(https://infograph.venngage.com/js/embed/v1/embed.js) venngage provided,
     // it addEventListener on 'load' event.
     // After 'load' event emits, it renders the iframe.
     // Hence, we emit the 'load' event after the script downloaded and executed.
-    const onLoad = function () {
-      const event = new Event('load')
-      window.dispatchEvent(event)
-    }
     const node = this.embedded
     const scripts = _.get(this.props, [ 'content', 0, 'scripts' ])
     if (node && Array.isArray(scripts)) {
@@ -62,7 +64,7 @@ export class EmbeddedCode extends React.Component {
         const dataset = this._pickDatasetFromAttribs(attribs)
         _.merge(scriptEle, attribs, { dataset })
         scriptEle.text = script.text || ''
-        scriptEle.onload = onLoad
+        scriptEle.onload = emitLoadEvent
         node.appendChild(scriptEle)
       })
     }

--- a/src/components/article/getArticleComponent.js
+++ b/src/components/article/getArticleComponent.js
@@ -12,52 +12,142 @@ import React from 'react'
 
 const modulePlaceHolder = null
 
+const audioLoadable = Loadable({
+  loader: () => import(
+    /* webpackChunkName: "audio" */
+    './Audio'
+  ),
+  render(loaded, props) {
+    const { Audio } = loaded
+    return <Audio {...props}/>
+  },
+  loading() {
+    return modulePlaceHolder
+  }
+})
+
+const blockquoteLoadable = Loadable({
+  loader: () => import(
+    /* webpackChunkName: "blockquote" */
+    './BlockQuote'
+  ),
+  render(loaded, props) {
+    const { BlockQuote } = loaded
+    return <BlockQuote {...props}/>
+  },
+  loading() {
+    return modulePlaceHolder
+  }
+})
+
+const quotebyLoadable = Loadable({
+  loader: () => import(
+    /* webpackChunkName: "quoteby" */
+    './BlockQuote'
+  ),
+  render(loaded, props) {
+    const { AlignedQuoteBy } = loaded
+    return <AlignedQuoteBy {...props}/>
+  },
+  loading() {
+    return modulePlaceHolder
+  }
+})
+
+const embeddedCodeLoadable = Loadable({
+  loader: () => import(
+    /* webpackChunkName: "embeddedcode" */
+    './Embedded'
+  ),
+  render(loaded, props) {
+    const { AlignedEmbedded } = loaded
+    return <AlignedEmbedded {...props}/>
+  },
+  loading() {
+    return modulePlaceHolder
+  }
+})
+
+const imageDiffLoadable = Loadable({
+  loader: () => import(
+    /* webpackChunkName: "imagediff" */
+    './ImageDiff'
+  ),
+  render(loaded, props) {
+    const { AlignedImageDiff } = loaded
+    return <AlignedImageDiff {...props}/>
+  },
+  loading() {
+    return modulePlaceHolder
+  }
+})
+
+const orderedListLoadable = Loadable({
+  loader: () => import(
+    /* webpackChunkName: "imagediff" */
+    './OrderedList'
+  ),
+  render(loaded, props) {
+    const { OrderedList } = loaded
+    return <OrderedList {...props}/>
+  },
+  loading() {
+    return modulePlaceHolder
+  }
+})
+
+const unorderedListLoadable = Loadable({
+  loader: () => import(
+    /* webpackChunkName: "unorderedlist" */
+    './UnorderedList'
+  ),
+  render(loaded, props) {
+    const { UnorderedList } = loaded
+    return <UnorderedList {...props}/>
+  },
+  loading() {
+    return modulePlaceHolder
+  }
+})
+
+const slideshowLoadable = Loadable({
+  loader: () => import(
+    /* webpackChunkName: "slideshow" */
+    './slideshow/slideshow'
+  ),
+  render(loaded, props) {
+    const { Slideshow } = loaded
+    return <Slideshow {...props}/>
+  },
+  loading() {
+    return modulePlaceHolder
+  }
+})
+
+const youtubeLoadable = Loadable({
+  loader: () => import(
+    /* webpackChunkName: "youtube" */
+    './Youtube'
+  ),
+  render(loaded, props) {
+    const { AlignedYoutube } = loaded
+    return <AlignedYoutube {...props}/>
+  },
+  loading() {
+    return modulePlaceHolder
+  }
+})
+
 export default function getArticleComponent(type = 'unstyled') {
   switch (type) {
     case 'annotation':
       return Annotation
     case 'audio':
-      return Loadable({
-        loader: () => import(
-          /* webpackChunkName: "audio" */
-          './Audio'
-        ),
-        render(loaded, props) {
-          const { Audio } = loaded
-          return <Audio {...props}/>
-        },
-        loading() {
-          return modulePlaceHolder
-        }
-      })
+      return audioLoadable
     case 'blockquote':
-      return Loadable({
-        loader: () => import(
-          /* webpackChunkName: "blockquote" */
-          './BlockQuote'
-        ),
-        render(loaded, props) {
-          const { BlockQuote } = loaded
-          return <BlockQuote {...props}/>
-        },
-        loading() {
-          return modulePlaceHolder
-        }
-      })
+      return blockquoteLoadable
     case 'quoteby':
-      return Loadable({
-        loader: () => import(
-          /* webpackChunkName: "quoteby" */
-          './BlockQuote'
-        ),
-        render(loaded, props) {
-          const { AlignedQuoteBy } = loaded
-          return <AlignedQuoteBy {...props}/>
-        },
-        loading() {
-          return modulePlaceHolder
-        }
-      })
+      return quotebyLoadable
     case 'header-one':
       return HeaderOne
     case 'header-two':
@@ -66,96 +156,24 @@ export default function getArticleComponent(type = 'unstyled') {
       return null
     case 'embeddedCode':
     case 'embeddedcode':
-      return Loadable({
-        loader: () => import(
-          /* webpackChunkName: "embeddedcode" */
-          './Embedded'
-        ),
-        render(loaded, props) {
-          const { AlignedEmbedded } = loaded
-          return <AlignedEmbedded {...props}/>
-        },
-        loading() {
-          return modulePlaceHolder
-        }
-      })
+      return embeddedCodeLoadable
     case 'image':
       return AlignedImage
     case 'imageDiff':
     case 'imagediff':
-      return Loadable({
-        loader: () => import(
-          /* webpackChunkName: "imagediff" */
-          './ImageDiff'
-        ),
-        render(loaded, props) {
-          const { AlignedImageDiff } = loaded
-          return <AlignedImageDiff {...props}/>
-        },
-        loading() {
-          return modulePlaceHolder
-        }
-      })
+      return imageDiffLoadable
     case 'infobox':
       return AlignedInfoBox
     case 'ordered-list-item':
-      return Loadable({
-        loader: () => import(
-          /* webpackChunkName: "imagediff" */
-          './OrderedList'
-        ),
-        render(loaded, props) {
-          const { OrderedList } = loaded
-          return <OrderedList {...props}/>
-        },
-        loading() {
-          return modulePlaceHolder
-        }
-      })
+      return orderedListLoadable
     case 'unordered-list-item':
-      return Loadable({
-        loader: () => import(
-          /* webpackChunkName: "unorderedlist" */
-          './UnorderedList'
-        ),
-        render(loaded, props) {
-          const { UnorderedList } = loaded
-          return <UnorderedList {...props}/>
-        },
-        loading() {
-          return modulePlaceHolder
-        }
-      })
+      return unorderedListLoadable
     case 'unstyled':
       return Paragraph
     case 'slideshow':
-      return Loadable({
-        loader: () => import(
-          /* webpackChunkName: "slideshow" */
-          './slideshow/slideshow'
-        ),
-        render(loaded, props) {
-          const { Slideshow } = loaded
-          return <Slideshow {...props}/>
-        },
-        loading() {
-          return modulePlaceHolder
-        }
-      })
+      return slideshowLoadable
     case 'youtube':
-      return Loadable({
-        loader: () => import(
-          /* webpackChunkName: "youtube" */
-          './Youtube'
-        ),
-        render(loaded, props) {
-          const { AlignedYoutube } = loaded
-          return <AlignedYoutube {...props}/>
-        },
-        loading() {
-          return modulePlaceHolder
-        }
-      })
+      return youtubeLoadable
     default:
       return
   }


### PR DESCRIPTION
Fix venngage embedded code was replace when embedded code is updated:
- Save return value of Loadable into closure to prevent creating new Component every time `getComponent` is called
- Update EmbeddedCode to PureComponent to prevent rerender when props not changed