### PR TITLE
[Bug] Fix background color of footer in article pages and remove static file path from props of Footer component

### DIFF
--- a/src/constants/static-file-prefix.js
+++ b/src/constants/static-file-prefix.js
@@ -1,8 +1,0 @@
-import { SITE_META } from '../constants/site-meta'
-
-const IMAGES_FOLDER = 'images'
-const storageURLTemplate = `${SITE_META.URL_NO_SLASH}/${IMAGES_FOLDER}/`
-
-export function storageUrlPrefix(SUBFOLDER_OF_IMAGES) {
-  return `${storageURLTemplate}${SUBFOLDER_OF_IMAGES}/`
-}

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -1,7 +1,6 @@
 /*eslint no-unused-vars:0, no-console:0 */
 import { connect } from 'react-redux'
 import { SITE_NAME, SITE_META } from '../constants/index'
-import { storageUrlPrefix } from '../constants/static-file-prefix'
 import categoryString from '../constants/category-strings'
 import categoryURI from '../conf/category-uri'
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
@@ -310,7 +309,6 @@ class Homepage extends React.PureComponent {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(siteNavigationJSONLD) }} />
         <Footer 
           bgColor={moduleBackgounds.footer}
-          staticFilePrefix={storageUrlPrefix('footer')}
         />
       </Container>
     )

--- a/src/helpers/with-layout.js
+++ b/src/helpers/with-layout.js
@@ -1,11 +1,12 @@
-import Footer from '@twreporter/react-components/lib/footer'
-import Header from '@twreporter/react-components/lib/header'
-import PropTypes from 'prop-types'
-import React from 'react'
+import { storageUrlPrefix } from '../constants/static-file-prefix'
 import constPageThemes from '../constants/page-themes'
 import constPropTypes from '../constants/prop-types'
+import Footer from '@twreporter/react-components/lib/footer'
+import Header from '@twreporter/react-components/lib/header'
 import hoistStatics from 'hoist-non-react-statics'
 import merge from 'lodash/merge'
+import PropTypes from 'prop-types'
+import React from 'react'
 import styled from 'styled-components'
 
 const  _  = {
@@ -39,7 +40,8 @@ class Layout extends React.PureComponent {
         </HeaderContainer>
         {this.props.children}
         <Footer
-          bgColor={theme.color.footerBg}
+          bgColor={constPageThemes.defaultTheme.color.footerBg}
+          staticFilePrefix={storageUrlPrefix('footer')}
         />
       </Container>
     )

--- a/src/helpers/with-layout.js
+++ b/src/helpers/with-layout.js
@@ -1,4 +1,3 @@
-import { storageUrlPrefix } from '../constants/static-file-prefix'
 import constPageThemes from '../constants/page-themes'
 import constPropTypes from '../constants/prop-types'
 import Footer from '@twreporter/react-components/lib/footer'
@@ -41,7 +40,6 @@ class Layout extends React.PureComponent {
         {this.props.children}
         <Footer
           bgColor={constPageThemes.defaultTheme.color.footerBg}
-          staticFilePrefix={storageUrlPrefix('footer')}
         />
       </Container>
     )


### PR DESCRIPTION
This patch adds static files prefix to pages footer apart from homepage. And uses default theme color as the constant `props` `bgColor`which is passed to Footer component. 