### PR TITLE
Updates in about-us page

### DIFF
--- a/src/components/about-us/constants/section-02/categories.js
+++ b/src/components/about-us/constants/section-02/categories.js
@@ -9,17 +9,17 @@ const media = [
     }
   },
   {
-    id: categoryIds.digital,
-    label: {
-      english: 'Digital Design and Development',
-      chinese: '數位部'
-    }
-  },
-  {
     id: categoryIds.photojournalist,
     label: {
       english: 'Photography Department',
       chinese: '攝影部'
+    }
+  },
+  {
+    id: categoryIds.digital,
+    label: {
+      english: 'Digital Design and Development',
+      chinese: '數位部'
     }
   }
 ]
@@ -35,6 +35,6 @@ const fundation = [
 ]
 
 export default {
-  media,
-  fundation
+  fundation,
+  media
 }

--- a/src/components/about-us/constants/section-02/category-ids.js
+++ b/src/components/about-us/constants/section-02/category-ids.js
@@ -1,8 +1,8 @@
 const categoryIds = {
+  fundation: 'fundation',
   editor: 'editor',
-  digital: 'digital',
   photojournalist: 'photojournalist',
-  fundation: 'fundation'
+  digital: 'digital'
 }
 
 export default categoryIds

--- a/src/components/about-us/section-02/content-carousel-list.js
+++ b/src/components/about-us/section-02/content-carousel-list.js
@@ -227,7 +227,7 @@ export default class CarouselMemberList extends PureComponent {
     window.addEventListener('resize', this._membersPageMaker)
   }
   componentWillUnmount() {
-    this.memberList = null
+    window.removeEventListener('resize', this._membersPageMaker)
     this.membersPageLengthArray = null
     this.membersResidueArray = null
     this.membersNumInAFullPageArray = null
@@ -357,9 +357,7 @@ export default class CarouselMemberList extends PureComponent {
               changePage = {this._changePage.bind(null, categoryIndex)}
             />
           </StyledArrows>
-          <PageWrapper
-            innerRef={(node) => { this.pageWrapper = node }}
-          >
+          <PageWrapper>
             <MemberList
               innerRef={memberList => this.memberList[categoryIndex] = memberList}
               shiftx = {this._getShiftX(categoryIndex)}

--- a/src/components/about-us/section-02/content-carousel-list.js
+++ b/src/components/about-us/section-02/content-carousel-list.js
@@ -21,7 +21,7 @@ const _ = {
   groupBy, find, values, keys, assign
 }
 
-const categoriesAll = categories.media.concat(categories.fundation)
+const categoriesAll = categories.fundation.concat(categories.media)
 const transitionDuration = 500
 
 const Container = styled.div`

--- a/src/components/about-us/section-02/content-paginated-list.js
+++ b/src/components/about-us/section-02/content-paginated-list.js
@@ -175,6 +175,7 @@ export default class PaginatedMemberList extends PureComponent {
     window.addEventListener('resize', this._pageMaker)
   }
   componentWillUnmount() {
+    window.removeEventListener('resize', this._pageMaker)
     this.membersPageLengthArray = null
   }
   render() {

--- a/src/components/about-us/section-02/content-paginated-list.js
+++ b/src/components/about-us/section-02/content-paginated-list.js
@@ -18,7 +18,7 @@ const _ = {
 }
 
 const numbersInOnePage = numbersInfullPage.mobile
-const categoriesAll = categories.media.concat(categories.fundation)
+const categoriesAll = categories.fundation.concat(categories.media)
 
 const Container = styled.div`
   position: relative;

--- a/src/components/about-us/section-02/index.js
+++ b/src/components/about-us/section-02/index.js
@@ -15,15 +15,15 @@ import mediaMembers from '../constants/section-02/media-members'
 import PaginatedMemberList from './content-paginated-list'
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
-import values from 'lodash/values'
+import categories from '../constants/section-02/categories'
 
 const _ = {
-  groupBy, find, values, keys
+  groupBy, find, keys
 }
 
-const members = mediaMembers.concat(foundationMembers)
+const members = foundationMembers.concat(mediaMembers)
 const groupedMembers = _.groupBy( members, member => member.category )
-const membersNumberArray = _.values(groupedMembers).map((membersArray) => { return membersArray.length })
+const membersNumberArray = [ ...categories.fundation, ...categories.media ].map((category) => { return groupedMembers[category.id].length})
 
 const Container = styled.div`
   position: relative;


### PR DESCRIPTION
This PR consists of two commits as below:

1. Changes the order of departments in section2 of about-us page. 
In this commit, I also uses `categories.js` file to keep the order and removes `lodash/value` since it returns the values of object `groupedMembers` and would lead to unexpected order.

2.  [Bug] Fix bug which causes error when clicking logo on the header of about-us page.
 Since React assigns refs back to null when it unmounts. When the component is being unmounted, the refs callback receives `null` as an argument. In our case, that is `(null) => this.memberList(index) = null` . And if we already set `this.memberList` (which is an array contains all of the refs) to null, it would cause the error.