### PR TITLE
fix Annotation Indicator positioning for FireFox

### DIFF
--- a/src/components/article/Annotation.scss
+++ b/src/components/article/Annotation.scss
@@ -108,6 +108,7 @@ $letter-spacing: .5px;
           &::after {
             top: 5px;
             border-width: 0 6px 6px;
+            height: 0;
           }
         }
       }


### PR DESCRIPTION
發現在 FireFox 上 `<abbr>` 展開後小白箭頭有正常倒轉，可是會往下方跑版

<img width="738" alt="default" src="https://user-images.githubusercontent.com/12410942/47582012-afe99a00-d985-11e8-9bb7-f0be1626224b.png">

原因似乎是 `::after` 的 height 在 FireFox 會被算成奇怪的高度（不確定是不是FireFox的bug）
<img width="1230" alt="default" src="https://user-images.githubusercontent.com/12410942/47582244-6b123300-d986-11e8-81a6-487ba74caa51.png">

但對 psudo element 加上 `height: 0;` 就會正常了

p.s. 實測 Chrome/Safari 因為原本的computed style的height就是0，所以改變前後皆正常
