### PR TITLE
Handle hash link scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ### Unreleased
+### 3.2.4
+- Handle hash link scroll. When url contains hash link like #section_1, browser will
+scroll to that anchor(id) properly.
+- fix(UI) position of annotation indicator on FireFox.
+
 ### 3.2.3
 - Add url to event label in google analysis click event
 - Update @twreporter/react-components@5.1.3

--- a/src/client.js
+++ b/src/client.js
@@ -21,6 +21,22 @@ if (window.__REDUX_STATE__) {
 
 function scrollToTopAndFirePageview() {
   if(window) {
+    // handle hash link scroll
+    // scroll to the anchor after DOM rendered
+    const { hash } = window.location
+    if (hash !== '') {
+      // Push onto callback queue so it runs after the DOM is updated,
+      // this is required when navigating from a different page so that
+      // the element is rendered on the page before trying to getElementById.
+      setTimeout(() => {
+        const id = hash.replace('#', '')
+        const element = document.getElementById(id)
+        if (element) {
+          element.scrollIntoView()
+        }
+      }, 0)
+      return
+    }
     window.scrollTo(0, 0)
     // send Google Analytics Pageview event on router changed
     ReactGA.pageview(window.location.pathname)


### PR DESCRIPTION
Handle hash link scroll. When url contains hash link like #section_1, browser will
scroll to that anchor(id) properly.