### PR TITLE
Change notify interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ### Unreleased
-- Tweak TopicLandingPage since the next version api will remove plain html  
 
+### 3.2.9
+- Tweak TopicLandingPage since the next version api will remove plain html  
+- Update the internal of showing web push confirmation check box from one day to one week.
+
+### Release
 ### 3.2.8
 - Slide down anchor panel layout change in about-us page
 - Update information and photos in about-us page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -363,9 +363,11 @@ class App extends PureComponent {
 
     // In order to reduce the interference,
     // if the user deny accepting notification,
-    // and then we ask them next day.
-    // 86400000 is one day in ms format
-    this.props.setNextPopupTS(Date.now() + 86400000)
+    // and then we ask them next week.
+    // 1000 * 60 * 60 * 24 * 7 is one week in ms format
+    const oneWeekInterval = 1000 * 60 * 60 * 24 * 7
+    const oneWeekLater = Date.now() + oneWeekInterval
+    this.props.setNextPopupTS(oneWeekLater)
   }
 
   _renderAcceptanceBox() {


### PR DESCRIPTION
### Change Log
- Change the interval time to ask users to confirm whether they want to receive the web push notifications from one day to one week.