### PR TITLE
Fix many components in topic landing page after testing on staging

### DIFF
--- a/src/components/topic/Description.js
+++ b/src/components/topic/Description.js
@@ -1,37 +1,23 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import YoutubePlayer from 'react-youtube'
-import constStyledComponents from '../../constants/styled-components'
 import getArticleComponent from '../article/getArticleComponent'
 import styled from 'styled-components'
-import PropTypes from 'prop-types'
 import { lineHeight, typography, colors } from '../../themes/common-variables'
+import { screen } from '../../themes/screen' 
 // lodash
 import get from 'lodash/get'
 
-const fontSize = 'medium'
+const mediumFontSize = 'medium'
 const redLineDistance = '40px'
-const contentSize = 'small'
+const smallContentSize = 'small'
 
 const _ = {
   get
 }
 
-const StyledTopicComponent = constStyledComponents.ResponsiveContainerForAritclePage.extend`
-  font-size: ${(props) => {
-    let fontSize = typography.font.size.base
-    switch(props.fontSize) {
-      case 'small':
-        fontSize = typography.font.size.xSmall
-        break
-      case 'large':
-        fontSize = typography.font.size.larger
-        break
-      default:
-        break
-    }
-    return fontSize
-  }};
-
+const StyledTopicComponent = styled.div`
+  font-size: ${props => props.fontSize};   
   margin-bottom: 40px;
 `
 
@@ -44,6 +30,8 @@ const Container = styled.div`
 
 const TopicDescription = styled.div`
   position: relative;
+  width: 38rem;
+  max-width: 90%;
   padding-bottom: ${redLineDistance};
   text-align: center;
   margin-left: auto;
@@ -52,7 +40,6 @@ const TopicDescription = styled.div`
   white-space: pre-wrap;
   line-height: ${lineHeight.linHeightLarge};
   color: ${colors.gray.gray15};
-
   p {
     margin-bottom: 1.5em;
   }
@@ -66,10 +53,6 @@ const TopicDescription = styled.div`
       &:hover {
         color: ${colors.primaryColor};
       }
-  }
-
-  iframe {
-    max-width: 100%;
   }
 
   /* horizontal rule */
@@ -89,8 +72,8 @@ const TopicDescription = styled.div`
   && * {
     font-size: ${typography.font.size.base};
     line-height: ${lineHeight.lineHeightLarge};
-    margin-bottom: 1.5em;
     text-align: center;
+    margin: 0 auto 1.5em auto;
   }
 `
 
@@ -141,15 +124,16 @@ const YoutubeContainer = styled.div`
   &&& * {
     margin-bottom: 0;
   }
-`
-
-const YoutubeIframeContainer = styled.div`
-  max-width: 100%;
-  margin-bottom: 0;
-  iframe,object,embed {
-    width: 560px;
-    height: 315px;
+  iframe {
+    max-width: 100%;
   }
+  ${screen.tabletAbove`
+    margin: 0 auto;
+    iframe {
+      width: 560px;
+      height: 315px;
+    }
+  `}
 `
 
 const DescTextBlock = styled.div`
@@ -160,68 +144,55 @@ const DescTextBlock = styled.div`
 }
 `
 
-const TopicDescriptionJSX = {
-  BlockQuote: (content) => {
+const TopicJSX = {
+  BlockQuote: (props) => {
     return (
-      <BlockQuote dangerouslySetInnerHTML={{ __html: _.get(content, [ 0 ], '') }}></BlockQuote>
+      <BlockQuote dangerouslySetInnerHTML={{ __html: _.get(props, [ 'content', 0 ], '') }}></BlockQuote>
     )
   },
-  Youtube: (content) => {
-    let { description, youtubeId } = _.get(content, [ 0 ], {})
+  Youtube: (props) => {
+    let { description, youtubeId } = _.get(props, [ 'content', 0 ], {})
     if (!youtubeId) {
       return null
     }
     return (
       <YoutubeContainer>
-        <YoutubeIframeContainer>
-          <YoutubePlayer videoId={youtubeId} />
-        </YoutubeIframeContainer>
+        <YoutubePlayer videoId={youtubeId} />
         <DescTextBlock>
           {description}
         </DescTextBlock>
       </YoutubeContainer>
     )
-  }
-}
-
-const TopicTeamJSX = {
-  Image: (content) => {
-    const imgSrc = _.get(content, [ 0, 'tablet', 'url' ], '')
+  },
+  Image: (props) => {
+    const imgSrc = _.get(props, [ 'content', 0, 'tablet', 'url' ], '')
     return (
       <img src={imgSrc} />
     )
   }
 }
 
-const getTopicContent = (data, contentType) => {
+const getTopicContent = (data) => {
   if (Array.isArray(data)) {
     return data.map((ele) => {
       let styles = {}
       let type = ele.type
-      let ArticleComponent = null
-      let TopicComponent = null
-      if (contentType === 'description') {
-        switch(type) {
-          case 'blockquote':
-            TopicComponent = TopicDescriptionJSX.BlockQuote
-            break
-          case 'youtube':
-            TopicComponent = TopicDescriptionJSX.Youtube
-            break
-          default:
-            ArticleComponent = getArticleComponent(type)
-        }
-      } else if (contentType === 'team') {
-        switch(type) {
-          case 'image':
-            TopicComponent = TopicTeamJSX.Image
-            break
-          default:
-            ArticleComponent = getArticleComponent(type)
-        }
+      let Component = null
+      switch(type) {
+        case 'blockquote':
+          Component = TopicJSX.BlockQuote
+          break
+        case 'youtube':
+          Component = TopicJSX.Youtube
+          break
+        case 'image':
+          Component = TopicJSX.Image
+          break
+        default:
+          Component = getArticleComponent(type)
       }
 
-      if (!ArticleComponent && !TopicComponent) {
+      if (!Component) {
         return null
       }
 
@@ -239,20 +210,16 @@ const getTopicContent = (data, contentType) => {
       return (
         <StyledTopicComponent
           key={ele.id}
-          fontSize={fontSize}
+          fontSize={mediumFontSize}
           style={styles}
-          headerOneText={type === 'header-one' ? _.get(ele, 'content.0') : ''}
-          size={contentSize}
+          size={smallContentSize}
         >
-          {
-            ArticleComponent ?
-              <ArticleComponent
-                alignment={ele.alignment}
-                content={ele.content}
-                id={ele.id}
-                styles={ele.styles}
-              />:TopicComponent(_.get(ele, 'content', []))
-          }
+          <Component
+            alignment={ele.alignment}
+            content={ele.content}
+            id={ele.id}
+            styles={ele.styles}
+          />
         </StyledTopicComponent>
       )
     })
@@ -264,10 +231,10 @@ const Description = (props) => {
   return (
     <Container>
       <TopicDescription>
-        {getTopicContent(topicDescription, 'description')}
+        {getTopicContent(topicDescription)}
       </TopicDescription>
       <TeamDescription>
-        {getTopicContent(teamDescription, 'team')}
+        {getTopicContent(teamDescription)}
       </TeamDescription>
     </Container>
   )

--- a/src/components/topic/Description.js
+++ b/src/components/topic/Description.js
@@ -1,22 +1,49 @@
 import React from 'react'
+import YoutubePlayer from 'react-youtube'
+import constStyledComponents from '../../constants/styled-components'
+import getArticleComponent from '../article/getArticleComponent'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { lineHeight, typography, colors } from '../../themes/common-variables'
+// lodash
+import get from 'lodash/get'
 
+const fontSize = 'medium'
 const redLineDistance = '40px'
+const contentSize = 'small'
+
+const _ = {
+  get
+}
+
+const StyledTopicComponent = constStyledComponents.ResponsiveContainerForAritclePage.extend`
+  font-size: ${(props) => {
+    let fontSize = typography.font.size.base
+    switch(props.fontSize) {
+      case 'small':
+        fontSize = typography.font.size.xSmall
+        break
+      case 'large':
+        fontSize = typography.font.size.larger
+        break
+      default:
+        break
+    }
+    return fontSize
+  }};
+
+  margin-bottom: 40px;
+`
 
 const Container = styled.div`
   position: relative;
   width: 100%;
   padding-top: 72px;
-  padding-bottom: 40px; 
+  padding-bottom: 40px;
 `
 
 const TopicDescription = styled.div`
   position: relative;
-  width: 38rem;
-  max-width: 90%;
-  
   padding-bottom: ${redLineDistance};
   text-align: center;
   margin-left: auto;
@@ -46,7 +73,7 @@ const TopicDescription = styled.div`
   }
 
   /* horizontal rule */
-  &::after { 
+  &::after {
     content: "";
     position: absolute;
     left: 0;
@@ -56,9 +83,18 @@ const TopicDescription = styled.div`
     margin: auto;
     border-top: 2px solid ${colors.red.rustyRed};
   }
+  /* Since the component corresponding to unstyled type uses a className to address text-align as justify.
+   * Boost the specificity of the override style by && instead of & here.
+   */
+  && * {
+    font-size: ${typography.font.size.base};
+    line-height: ${lineHeight.lineHeightLarge};
+    margin-bottom: 1.5em;
+    text-align: center;
+  }
 `
 
-const TeamDescriptiton = styled.div`
+const TeamDescription = styled.div`
   text-align: center;
   margin-left: auto;
   margin-right: auto;
@@ -68,9 +104,6 @@ const TeamDescriptiton = styled.div`
   color: ${colors.gray.gray50};
   line-height: ${lineHeight.linHeightLarge};
   margin-top: 40px;
-  p {
-    white-space: pre-wrap;
-  }
   a {
     border-bottom: 1px ${colors.primaryColor} solid;
     cursor: pointer;
@@ -81,21 +114,168 @@ const TeamDescriptiton = styled.div`
       color: ${colors.primaryColor};
     }
   }
+  /* Since the component corresponding to unstyled type uses a className to address text-align as justify.
+   * Boost the specificity of the override style by && instead of & here.
+   */
+  && * {
+    font-size: ${typography.font.size.small};
+    color: ${colors.gray.gray50};
+    line-height: ${lineHeight.lineHeightLarge};
+    text-align: center;
+    margin-bottom: 0;
+  }
 `
+
+const BlockQuote = styled.blockquote`
+  font-style: italic;
+  padding-left: 1rem;
+  line-height: 1.85;
+  font-size: 1rem;
+  font-weight: 300;
+  white-space: pre-wrap;
+  margin: 0 1.33rem 0 1.33rem;
+`
+
+const YoutubeContainer = styled.div`
+  width: 100%;
+  &&& * {
+    margin-bottom: 0;
+  }
+`
+
+const YoutubeIframeContainer = styled.div`
+  max-width: 100%;
+  margin-bottom: 0;
+  iframe,object,embed {
+    width: 560px;
+    height: 315px;
+  }
+`
+
+const DescTextBlock = styled.div`
+  color: #808080;
+  font-size: 0.88rem;
+  line-height: 1.8;
+  margin: 0.94rem 1.33rem 0 1.33rem;
+}
+`
+
+const TopicDescriptionJSX = {
+  BlockQuote: (content) => {
+    return (
+      <BlockQuote dangerouslySetInnerHTML={{ __html: _.get(content, [ 0 ], '') }}></BlockQuote>
+    )
+  },
+  Youtube: (content) => {
+    let { description, youtubeId } = _.get(content, [ 0 ], {})
+    if (!youtubeId) {
+      return null
+    }
+    return (
+      <YoutubeContainer>
+        <YoutubeIframeContainer>
+          <YoutubePlayer videoId={youtubeId} />
+        </YoutubeIframeContainer>
+        <DescTextBlock>
+          {description}
+        </DescTextBlock>
+      </YoutubeContainer>
+    )
+  }
+}
+
+const TopicTeamJSX = {
+  Image: (content) => {
+    const imgSrc = _.get(content, [ 0, 'tablet', 'url' ], '')
+    return (
+      <img src={imgSrc} />
+    )
+  }
+}
+
+const getTopicContent = (data, contentType) => {
+  if (Array.isArray(data)) {
+    return data.map((ele) => {
+      let styles = {}
+      let type = ele.type
+      let ArticleComponent = null
+      let TopicComponent = null
+      if (contentType === 'description') {
+        switch(type) {
+          case 'blockquote':
+            TopicComponent = TopicDescriptionJSX.BlockQuote
+            break
+          case 'youtube':
+            TopicComponent = TopicDescriptionJSX.Youtube
+            break
+          default:
+            ArticleComponent = getArticleComponent(type)
+        }
+      } else if (contentType === 'team') {
+        switch(type) {
+          case 'image':
+            TopicComponent = TopicTeamJSX.Image
+            break
+          default:
+            ArticleComponent = getArticleComponent(type)
+        }
+      }
+
+      if (!ArticleComponent && !TopicComponent) {
+        return null
+      }
+
+      if (type === 'embeddedcode') {
+        let embeddedContent = _.get(ele, [ 'content', 0 ], {})
+        let width = _.get(embeddedContent, 'width')
+        let height = _.get(embeddedContent, 'height')
+        if (width) {
+          styles.width = width
+        }
+        if (height) {
+          styles.minHeight = height
+        }
+      }
+      return (
+        <StyledTopicComponent
+          key={ele.id}
+          fontSize={fontSize}
+          style={styles}
+          headerOneText={type === 'header-one' ? _.get(ele, 'content.0') : ''}
+          size={contentSize}
+        >
+          {
+            ArticleComponent ?
+              <ArticleComponent
+                alignment={ele.alignment}
+                content={ele.content}
+                id={ele.id}
+                styles={ele.styles}
+              />:TopicComponent(_.get(ele, 'content', []))
+          }
+        </StyledTopicComponent>
+      )
+    })
+  }
+}
 
 const Description = (props) => {
   const { topicDescription, teamDescription } = props
   return (
     <Container>
-      <TopicDescription dangerouslySetInnerHTML={{ __html: topicDescription }} />
-      <TeamDescriptiton  dangerouslySetInnerHTML={{ __html: teamDescription }} />
+      <TopicDescription>
+        {getTopicContent(topicDescription, 'description')}
+      </TopicDescription>
+      <TeamDescription>
+        {getTopicContent(teamDescription, 'team')}
+      </TeamDescription>
     </Container>
   )
 }
 
 Description.propTypes = {
-  topicDescription: PropTypes.string.isRequired,
-  teamDescription: PropTypes.string.isRequired
+  topicDescription: PropTypes.array.isRequired,
+  teamDescription: PropTypes.array.isRequired
 }
 
 export default Description

--- a/src/containers/TopicLandingPage.js
+++ b/src/containers/TopicLandingPage.js
@@ -60,7 +60,7 @@ class TopicLandingPage extends Component {
     const slug = _.get(params, 'slug')
     fetchAFullTopic(slug)
   }
-  
+
   componentDidMount() {
     this._updateViewportHeight()
   }
@@ -131,8 +131,8 @@ class TopicLandingPage extends Component {
     const bannerTheme = _.get(topic, 'titlePosition') || 'center' // {string} - Theme of banner
     const cardsTheme = _.get(topic, 'relatedsFormat') || 'in-row' // {string} - Theme of cards
     const cardsContainerBgColor = _.get(topic, 'relatedsBackground') || '#d8d8d8' // {string} - HEX value of cards container bg-color
-    const description = _.get(topic, 'description.html', '') // {string}
-    const teamDescription = _.get(topic, 'teamDescription.html', '') // {string}
+    const description = _.get(topic, 'description.apiData', []) // {array}
+    const teamDescription = _.get(topic, 'teamDescription.apiData', []) // {array}
     const ogDescription =  _.get(topic, 'ogDescription') || SITE_META.DESC // {string}
     const ogTitle = _.get(topic, 'ogTitle', '') || _.get(topic, 'title', '')
     const ogImage = _.get(leadingImage, 'resizedTargets.tablet.url') || SITE_META.OG_IMAGE // {string}

--- a/src/helpers/Html.js
+++ b/src/helpers/Html.js
@@ -48,7 +48,7 @@ injectGlobal`
     }
 
     .container {
-      line-height: ${lineHeight.linHeightLarge};
+      line-height: ${lineHeight.lineHeightLarge};
     }
 
     .no-hover {

--- a/src/themes/common-variables.js
+++ b/src/themes/common-variables.js
@@ -21,7 +21,7 @@ export const typography = {
 export const lineHeight = {
   lineHeightMedium: '1.4',
   lineHeightBase: '1.5',
-  linHeightLarge: '1.8',
+  lineHeightLarge: '1.8',
   lineHeightParagraph: '1.95'
 }
 


### PR DESCRIPTION
This patch aims to fix topic landing page which has been merged in this [PR](https://github.com/twreporter/twreporter-react/pull/1083) and was reverted after testing on staging server.

## Change List
- Removed the `Body` component which is used in article pages and reused `getArticleComponent` instead
- Fix  components returned in type `blockquote`, `youtube`, `image` in team description, and abnormal "double" underline hyper links in topic description texts
- Fix the typo `linHeightLarge` in `common-variables`