### PR TITLE
bugfix: Centerized images in teamDescription (topicLandingPage)

### DIFF
--- a/src/components/topic/Description.js
+++ b/src/components/topic/Description.js
@@ -105,7 +105,7 @@ const TeamDescription = styled.div`
     color: ${colors.gray.gray50};
     line-height: ${lineHeight.lineHeightLarge};
     text-align: center;
-    margin-bottom: 0;
+    margin: 0 auto;
   }
 `
 


### PR DESCRIPTION
## Change Log
This patch fixes images that are not being centered in `topicLandingPage` `teamDescription`