### PR TITLE
Remove props `history` from `BrowserRouter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Unreleased
+
+## Release
+### 4.0.1
+- Remove props `history` from `BrowserRouter`.
+
 ### 4.0.0
 #### Major change
 ##### Dependencies Upgrade
@@ -31,7 +36,6 @@
 - Move category related constants into src/constants/category.js
 - Update src/containers/app-shell.js. Refactor web push registration promise chain
 
-## Release
 ### 3.2.10
 - Tweak TopicLandingPage container due to api changes (remove plain html) 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",

--- a/src/client.js
+++ b/src/client.js
@@ -10,7 +10,6 @@ import ReactGA from 'react-ga'
 import configureStore from './store/configure-store'
 import { BrowserRouter, Route } from 'react-router-dom'
 import { Provider } from 'react-redux'
-import { createBrowserHistory } from 'history'
 
 let reduxState
 
@@ -52,12 +51,10 @@ configureStore(reduxState)
       ReactGA.set({ page: window.location.pathname })
     }
 
-    const history = createBrowserHistory()
-
     const releaseBranch = process.env.RELEASE_BRANCH || 'master'
     const jsx = (
       <Provider store={store}>
-        <BrowserRouter history={history}>
+        <BrowserRouter>
           <React.Fragment>
             <Route path="/" component={scrollToTopAndFirePageview} />
             <App releaseBranch={releaseBranch}/>


### PR DESCRIPTION
### PR Description
Currently, we pass `history` object as props into`BrowserRouter`.
However, `BrowserRouter` has its own `history` object already.
So, we remove passing `history` prop.

### Change Log
- Remove props `history` from `BrowserRouter`