### PR TITLE
Add a workaround to author data problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+### 3.2.13
+- [Bug] Add a workaround to author data problem
+
 ### Release
 ### 3.2.12
 - [Bug] Fix about-us page opening layout which got wrong height (100 viewport height) when client width is smaller than desktop and larger than tablet breakpoint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -52,6 +52,13 @@ const rootReducer = combineReducers({
   [reduxStatePropKey.entitiesForAuthors]: (state = {}, action) => {
     const entities = _.get(action, 'normalizedData.entities')
     if (entities) {
+      // WORKAROUND:
+      // When the data of an author is updated, we have not build the function to synchronize the author data saved in old post records on Algolia.
+      // So the author data in post records that already existed will be outdated.
+      // The temporarily solution is that we do not update authors in entities when fetching articles of an author.
+      if (action.type === types.FETCH_AUTHOR_COLLECTION_SUCCESS) {
+        return _.merge({}, state, { articles: entities.articles })
+      }
       return _.merge({}, state, entities)
     }
     return state


### PR DESCRIPTION
When the data of an author is updated, we have not build the function to synchronize the author data saved in old post records on Algolia.
So the author data in post records that already existed will be outdated.
The temporarily solution is that we do not update authors in entities when fetching articles of an author.