### PR TITLE
Article layout adjustment

### DIFF
--- a/src/components/article/layout/layout-maker.js
+++ b/src/components/article/layout/layout-maker.js
@@ -5,13 +5,11 @@ import LeadingVideo from '../../shared/LeadingVideo'
 import React from 'react'
 import TitleRowAbove from './title-row-above'
 import TitleRowUpon from './title-row-upon'
-import constPageThemes from '../../../constants/page-themes'
 import constStyledComponents from '../../../constants/styled-components'
 import get from 'lodash/get'
 import merge from 'lodash/merge'
 import styled from 'styled-components'
 import { screen } from '../../../themes/screen'
-
 
 const _ = {
   get,
@@ -19,22 +17,33 @@ const _ = {
 }
 
 const MetaContainer = styled.div`
-  margin-top: ${props => props.titlePosition === constPageThemes.position.title.uponLeft ? '60px' : '24px'};
+  margin-top: ${props => props.isLeadingAssetFullScreen ? '60px' : '24px'};
   margin-bottom: 40px;
 `
 
 const LayoutContainer = styled.div`
-  margin-top: ${props => {
+  ${screen.mobile`
+    margin-top: ${props => {
     // -110px is the header's height
-    return props.headerPosition === constPageThemes.position.header.upon ? '-110px' : '0px'
+    return props.isLeadingAssetFullScreen ? '-110px' : '0px'
   }};
-
-  ${screen.desktopBelow`
-    margin-top: 0px;
   `}
+
   position: relative;
   width: 100%;
   height: 100%;
+`
+
+const FullScreenContainer = styled.div`
+  position: relative;
+`
+
+const FullScreenOverlayMask = styled.div`
+  position: absolute;
+  height: 50%;
+  width: 100%;
+  bottom: 0;
+  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), #000000);
 `
 
 
@@ -61,33 +70,46 @@ function composeAuthors(article) {
 }
 
 /**
+ * LayoutStyle type definition
+ * @typedef {Object} LayoutStyle
+ * @property {Object} title - title styles object
+ * @property {string} title.fontColor - font-color of title
+ * @property {Object} subtitle - subtitle styles object
+ * @property {string} subtitle.fontColor - font-color of subtitle
+ * @property {Object} topic - topic styles object
+ * @property {string} topic.fontColor - font-color of topic
+ * /
+
+/**
  * Render `TitleRowAbove` or `TitleRowUpon` according to title's position.
  * If position is 'above', which means title is above the hero image/leading video.
  * If position is 'upon-left', which means title overlays left on the hero image/leading video.
  *
- * @param {string} [position='above'] - Title's position
+ * @param {boolean} [isLeadingAssetFullScreen=false] - indicate if the leading asset to be the full screen or not
  * @param {Object} [props={}] - Properties `TitleRowAbove` and `TitleRowUpon` needed
  * @param {string} props.title
  * @param {string} props.subtitle
  * @param {string} props.topicName
  * @param {string} props.topicSlug
- * @param {Object} props.theme - theme object
+ * @param {LayoutStyle} props.styles - styles for layout
+ *
  * @returns {Object} React component, either `TitleRowAbove` or `TitleRowUpon`
  */
-function renderTitleOnDemand(position=constPageThemes.position.title.above, props={}) {
-  const { title, subtitle, topicName, topicSlug, theme } = props
+function renderTitleOnDemand(isLeadingAssetFullScreen, props={}) {
+  const { title, subtitle, topicName, topicSlug, styles } = props
 
   let Component = TitleRowAbove
-  if (position === constPageThemes.position.title.uponLeft) {
+  if (isLeadingAssetFullScreen) {
     Component = TitleRowUpon
   }
+
   return (
     <Component
       title={title}
       subtitle={subtitle}
       topicName={topicName}
       topicSlug={topicSlug}
-      theme={theme}
+      styles={styles}
     />
   )
 }
@@ -98,17 +120,16 @@ function renderTitleOnDemand(position=constPageThemes.position.title.above, prop
  * If position is 'above', render `HeroImage`.
  * If position is 'upon-left', render `FullScreenImage`
 *
+ * @param {boolean} [isLeadingAssetFullScreen=false] - indicate if the leading asset to be full screen or not
  * @param {Object} [props={}] - Properties `LeadingVideo`, `HeroImage` or `FullScreenImage` needed
  * @param {Object} props.video - video object, details are specified in `videoObj` of `src/constants/prop-types.js`
  * @param {Object} props.heroImage - image object, details are specified in `imgObj` of `src/constants/prop-types.js`
  * @param {Object} props.portraitHeroImage - image object, details are specified in `imgObj` of `src/constants/prop-types.js`
- * @param {string} [position='above'] - Title's position
  * @param {string} props.alt
  * @param {string} props.size - hero image size, could be 'small', 'medium' and 'extend'
- * @param {Object} props.theme - theme object
- * @returns {Object} React component, either `TitleRowAbove` or `TitleRowUpon`
+ * @returns {Object} React component
  */
-function renderLeadingMediaAssetOnDemand(position=constPageThemes.position.title.above, props={}) {
+function renderLeadingMediaAssetOnDemand(isLeadingAssetFullScreen, props={}) {
   const { heroImage, portraitHeroImage, alt, size, video } = props
   if (video) {
     return (
@@ -126,13 +147,16 @@ function renderLeadingMediaAssetOnDemand(position=constPageThemes.position.title
     )
   }
 
-  if (position === constPageThemes.position.title.uponLeft) {
+  if (isLeadingAssetFullScreen) {
     return (
-      <FullScreenImage
-        alt={alt}
-        imgSet={_.get(heroImage, 'resizedTargets')}
-        portraitImgSet={_.get(portraitHeroImage, 'resizedTargets')}
-      />
+      <FullScreenContainer>
+        <FullScreenImage
+          alt={alt}
+          imgSet={_.get(heroImage, 'resizedTargets')}
+          portraitImgSet={_.get(portraitHeroImage, 'resizedTargets')}
+        />
+        <FullScreenOverlayMask />
+      </FullScreenContainer>
     )
   }
   return (
@@ -151,18 +175,27 @@ function renderLeadingMediaAssetOnDemand(position=constPageThemes.position.title
  * @param {Object} props - default value is {}
  * @param {Object} props.article - article object
  * @param {Object} props.topic - topic object
- * @param {Object} props.theme - theme object
+ * @param {boolean} props.isLeadingAssetFullScreen - indicate if the leading video/image to be full screen or not
  * @param {string} props.fontSize
+ * @param {LayoutStyle} props.styles - styles for layout
+ *
  * @param {function} props.changeFontSize
  * @returns {Object} React components in order
  */
 function renderLayout(props={}) {
-  const { article, topic, theme, fontSize, changeFontSize } = props
+  const {
+    article,
+    changeFontSize,
+    fontSize,
+    isLeadingAssetFullScreen,
+    styles,
+    topic
+  } = props
 
   const _article = article || {}
   const _topic = topic || {}
 
-  const leadingMediaAssetJSX = renderLeadingMediaAssetOnDemand(_.get(theme, 'position.title'), {
+  const leadingMediaAssetJSX = renderLeadingMediaAssetOnDemand(isLeadingAssetFullScreen, {
     alt: _article.leadingImageDescription,
     heroImage: _article.heroImage,
     portraitHeroImage: _article.leadingImagePortrait,
@@ -172,7 +205,7 @@ function renderLayout(props={}) {
 
   const metaJSX = (
     <MetaContainer
-      titlePosition={_.get(theme, 'position.title')}
+      isLeadingAssetFullScreen={isLeadingAssetFullScreen}
     >
       <ArticleMeta
         authors={composeAuthors(_article)}
@@ -185,8 +218,8 @@ function renderLayout(props={}) {
     </MetaContainer>
   )
 
-  const order = _.get(theme, 'position.title') === constPageThemes.position.title.uponLeft ?
-    [ leadingMediaAssetJSX, metaJSX ] : [ metaJSX, leadingMediaAssetJSX ]
+  const order = isLeadingAssetFullScreen ? [ leadingMediaAssetJSX, metaJSX ] :
+    [ metaJSX, leadingMediaAssetJSX ]
 
   return (
     <div
@@ -195,12 +228,12 @@ function renderLayout(props={}) {
       }}
     >
       <LayoutContainer
-        headerPosition={_.get(theme, 'position.header')}
+        isLeadingAssetFullScreen={isLeadingAssetFullScreen}
       >
-        {renderTitleOnDemand(_.get(theme, 'position.title'), {
+        {renderTitleOnDemand(isLeadingAssetFullScreen, {
           subtitle: _article.subtitle,
-          theme,
           title: _article.title,
+          styles,
           topicName: _topic.topicName,
           topicSlug: _topic.slug
         })}

--- a/src/components/article/layout/title-row-above.js
+++ b/src/components/article/layout/title-row-above.js
@@ -1,8 +1,6 @@
 import Link from 'react-router-dom/Link'
 import PropTypes from 'prop-types'
 import React from 'react'
-import constPageThemes from '../../../constants/page-themes'
-import constPropTypes from '../../../constants/prop-types'
 import get from 'lodash/get'
 import styled from 'styled-components'
 import { LINK_PREFIX } from '../../../constants/index'
@@ -106,17 +104,17 @@ const RightArrow = styled.div`
 
 class TitleRowAbove extends React.PureComponent {
   render() {
-    const { title, subtitle, topicName, topicSlug, theme } = this.props
+    const { title, subtitle, topicName, topicSlug, styles } = this.props
     const topicJSX = topicName ? (
       <Topic>
         <Link
           to={`${LINK_PREFIX.TOPICS}${topicSlug}`}
         >
           <TopicContent
-            color={_.get(theme, 'color.topic')}
+            color={_.get(styles, 'topic.fontColor')}
           >
             {topicName}
-            <RightArrow color={_.get(theme, 'color.topic')}/>
+            <RightArrow color={_.get(styles, 'topic.fontColor')}/>
           </TopicContent>
         </Link>
       </Topic>
@@ -125,7 +123,7 @@ class TitleRowAbove extends React.PureComponent {
     const subtitleJSX = subtitle ? (
       <Subtitle
         itemProp="alternativeHeadline"
-        color={_.get(theme, 'color.subtitle')}
+        color={_.get(styles, 'subtitle.fontColor')}
       >
         {subtitle}
       </Subtitle>
@@ -143,7 +141,7 @@ class TitleRowAbove extends React.PureComponent {
         <HeaderContainer>
           {firstRowJSX}
           <Title
-            color={_.get(theme, 'color.title')}
+            color={_.get(styles, 'title.fontColor')}
           >
             {title}
           </Title>
@@ -157,7 +155,7 @@ TitleRowAbove.defaultProps = {
   subtitle: '',
   topicName: '',
   topicSlug: '',
-  theme: constPageThemes.defaultTheme
+  styles: {}
 }
 
 TitleRowAbove.propTypes = {
@@ -165,7 +163,17 @@ TitleRowAbove.propTypes = {
   title: PropTypes.string.isRequired,
   topicName: PropTypes.string,
   topicSlug: PropTypes.string,
-  theme: constPropTypes.theme
+  styles: PropTypes.shape({
+    subtitle: PropTypes.shape({
+      fontColor: PropTypes.string
+    }),
+    title: PropTypes.shape({
+      fontColor: PropTypes.string
+    }),
+    topic: PropTypes.shape({
+      fontColor: PropTypes.string
+    })
+  })
 }
 
 export default TitleRowAbove

--- a/src/components/article/layout/title-row-upon.js
+++ b/src/components/article/layout/title-row-upon.js
@@ -1,8 +1,6 @@
 import Link from 'react-router-dom/Link'
 import PropTypes from 'prop-types'
 import React from 'react'
-import constPageThemes  from '../../../constants/page-themes'
-import constPropTypes from '../../../constants/prop-types'
 import get from 'lodash/get'
 import styled from 'styled-components'
 import { LINK_PREFIX } from '../../../constants/index'
@@ -26,28 +24,35 @@ const colorselector = (props, defaultColor) => {
 const Container = styled.div`
   z-index: 100;
   position: absolute;
-  left: 70px;
+  left: 65px;
   ${screen.overDesktop`
-    top: 35%;
+    bottom: 100px;
     width: 45%;
   `}
   ${screen.desktop`
-    top: 29%;
+    bottom: 85px;
     width: 55%;
   `}
   ${screen.tablet`
-    left: 7%;
-    top: 23%;
+    left: 35px;
+    bottom: 37px;
     width: 70%;
   `}
   ${screen.mobile`
     width: 60%;
-    top: 27%;
-    left: 9%;
+    bottom: 60px;
+    left: 30px;
   `}
 `
 
-const HeaderContainer = styled.hgroup``
+const HeaderContainer = styled.hgroup`
+  > div:first-child {
+    margin-bottom: 25px;
+  }
+  > div:last-child {
+    margin-top: 20px;
+  }
+`
 
 // #############################
 // Fundemenatal Elements
@@ -62,25 +67,30 @@ const Title = styled(HeaderElementBlock)`
   font-weight: ${typography.font.weight.bold};
   line-height: 1.4;
   color: ${props => (colorselector(props, colors.gray.gray25))};
-  font-size: 60px;
+  font-size: 50px;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   ${screen.mobile`
-    font-size: 36px;
+    font-size: 32px;
   `}
 `
 
 const Subtitle = styled(HeaderElementBlock)`
   color: ${props => (colorselector(props, colors.gray.gray50))};
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   font-size: ${typography.font.size.medium};
   font-weight: ${typography.font.weight.extraLight};
   ${screen.tabletAbove`
-    font-size: 50px;
+    font-size: 40px;
   `}
   ${screen.mobile`
-    font-size: 30px;
+    font-size: 26px;
   `}
 `
 
 const Topic = styled(HeaderElementBlock)`
+  display: inline-block;
+  padding: 5px;
+  background-color: rgba(166, 122, 68, 0.55);
   > a {
     text-decoration: none !important;
     border: 0 !important;
@@ -109,17 +119,17 @@ const RightArrow = styled.div`
 
 class TitleRowUpon extends React.PureComponent {
   render() {
-    const { title, subtitle, topicName, topicSlug, theme } = this.props
+    const { title, subtitle, topicName, topicSlug, styles } = this.props
     const topicJSX = topicName ? (
       <Topic>
         <Link
           to={`${LINK_PREFIX.TOPICS}${topicSlug}`}
         >
           <TopicContent
-            color={_.get(theme, 'color.topic')}
+            color={_.get(styles, 'topic.fontColor')}
           >
             {topicName}
-            <RightArrow color={_.get(theme, 'color.topic')}/>
+            <RightArrow color={_.get(styles, 'topic.fontColor')}/>
           </TopicContent>
         </Link>
       </Topic>
@@ -128,7 +138,7 @@ class TitleRowUpon extends React.PureComponent {
     const subtitleJSX = subtitle ? (
       <Subtitle
         itemProp="alternativeHeadline"
-        color={_.get(theme, 'color.subtitle')}
+        color={_.get(styles, 'subtitle.fontColor')}
       >
         {subtitle}
       </Subtitle>
@@ -139,7 +149,7 @@ class TitleRowUpon extends React.PureComponent {
         <HeaderContainer>
           {topicJSX}
           <Title
-            color={_.get(theme, 'color.title')}
+            color={_.get(styles, 'title.fontColor')}
           >
             {title}
           </Title>
@@ -154,7 +164,7 @@ TitleRowUpon.defaultProps = {
   subtitle: '',
   topicName: '',
   topicSlug: '',
-  theme: constPageThemes.defaultTheme
+  styles: {}
 }
 
 TitleRowUpon.propTypes = {
@@ -162,7 +172,17 @@ TitleRowUpon.propTypes = {
   title: PropTypes.string.isRequired,
   topicName: PropTypes.string,
   topicSlug: PropTypes.string,
-  theme: constPropTypes.theme
+  styles: PropTypes.shape({
+    subtitle: PropTypes.shape({
+      fontColor: PropTypes.string
+    }),
+    title: PropTypes.shape({
+      fontColor: PropTypes.string
+    }),
+    topic: PropTypes.shape({
+      fontColor: PropTypes.string
+    })
+  })
 }
 
 

--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -9,22 +9,20 @@ import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import ReadingProgress from '../components/article/ReadingProgress'
 import SystemError from '../components/SystemError'
-import commonStyles from '../components/article/Common.scss'
-import constPropTypes from '../constants/prop-types'
+import commonClassNames from '../components/article/Common.scss'
 import cx from 'classnames'
 import deviceConst from '../constants/device'
 import DonationBox from '../components/shared/DonationBox'
-import constPageThemes from '../constants/page-themes'
 import constStyledComponents from '../constants/styled-components'
 import styled from 'styled-components'
-import styles from './Article.scss'
+import classNames from './Article.scss'
 import twreporterRedux from '@twreporter/redux'
 import layoutMaker from '../components/article/layout/layout-maker'
 import { Body } from '../components/article/Body'
 import { BottomRelateds } from '../components/article/BottomRelateds'
 import { BottomTags } from '../components/article/BottomTags'
 import { Introduction } from '../components/article/Introduction'
-import { PHOTOGRAPHY_ARTICLE_STYLE, SITE_META, SITE_NAME } from '../constants/index'
+import { SITE_META, SITE_NAME } from '../constants/index'
 import { articleLayout as layout } from '../themes/layout'
 import { camelizeKeys } from 'humps'
 import { connect } from 'react-redux'
@@ -32,6 +30,7 @@ import { date2yyyymmdd } from '../utils/date'
 import { getScreenType } from '../utils/screen'
 import { colors } from '../themes/common-variables'
 import { screen } from '../themes/screen'
+import { themesConst } from '../managers/theme-manager'
 
 // lodash
 import forEach from 'lodash/forEach'
@@ -97,21 +96,21 @@ const scrollPosition = {
 const ArticlePlaceholder = () => {
   return (
     <constStyledComponents.ResponsiveContainerForAritclePage>
-      <div className={cx(styles['placeholder'])}>
-        <div className={cx(styles['title-row'], commonStyles['inner-block'])}>
-          <div className={styles['ph-title-1']}></div>
-          <div className={styles['ph-title-2']}></div>
-          <div className={styles['ph-author']}></div>
+      <div className={classNames['placeholder']}>
+        <div className={cx(classNames['title-row'], commonClassNames['inner-block'])}>
+          <div className={classNames['ph-title-1']}></div>
+          <div className={classNames['ph-title-2']}></div>
+          <div className={classNames['ph-author']}></div>
         </div>
-        <div className={styles['leading-img']}>
-          <div className={styles['ph-image']}>
-            <LogoIcon className={styles['logo-icon']} />
+        <div className={classNames['leading-img']}>
+          <div className={classNames['ph-image']}>
+            <LogoIcon className={classNames['logo-icon']} />
           </div>
         </div>
         <IntroductionContainer>
-          <div className={styles['ph-content']}></div>
-          <div className={styles['ph-content']}></div>
-          <div className={styles['ph-content-last']}></div>
+          <div className={classNames['ph-content']}></div>
+          <div className={classNames['ph-content']}></div>
+          <div className={classNames['ph-content-last']}></div>
         </IntroductionContainer>
       </div>
     </constStyledComponents.ResponsiveContainerForAritclePage>
@@ -145,7 +144,7 @@ class Article extends PureComponent {
     let post = _.get(entities, [ reduxStateFields.postsInEntities, slug ], {})
     let style = _.get(post, 'style')
     return {
-      isPhotography: style === PHOTOGRAPHY_ARTICLE_STYLE,
+      isPhotography: style === themesConst.photography,
       location
     }
   }
@@ -304,7 +303,7 @@ class Article extends PureComponent {
   }
 
   render() {
-    const { entities, match, selectedPost, theme } = this.props
+    const { entities, match, selectedPost, isLeadingAssetFullScreen, styles } = this.props
     const { fontSize } = this.state
     const error = _.get(selectedPost, 'error')
     if (error) {
@@ -349,7 +348,8 @@ class Article extends PureComponent {
     const layoutJSX = layoutMaker.renderLayout({
       article,
       topic,
-      theme,
+      isLeadingAssetFullScreen,
+      styles,
       fontSize,
       changeFontSize: this.changeFontSize
     })
@@ -380,7 +380,7 @@ class Article extends PureComponent {
             <React.Fragment>
               <ReadingProgress ref={ele => this.rp = ele}/>
               <ArticleContainer
-                fontColor={theme.color.font}
+                fontColor={styles.text.fontColor}
                 ref={div => {this.progressBegin = div}}
               >
                 <div itemProp="publisher" itemScope itemType="http://schema.org/Organization">
@@ -437,46 +437,6 @@ class Article extends PureComponent {
   }
 }
 
-export function mapStateToProps(state) {
-  const entities = state[reduxStateFields.entities]
-  const selectedPost = state[reduxStateFields.selectedPost]
-  const post = _.get(entities, [ reduxStateFields.postsInEntities, selectedPost.slug ], {})
-  const style = post.style
-  let theme
-
-  if (!_.get(post, 'theme')) {
-    // backwards compatible for photo articles
-    if (style === PHOTOGRAPHY_ARTICLE_STYLE) {
-      theme = constPageThemes.photoTheme
-    } else {
-      theme = constPageThemes.defaultTheme
-    }
-  } else {
-    const rawTheme = post.theme
-    theme = {
-      color: {
-        bg: rawTheme.bg_color,
-        font: rawTheme.font_color,
-        footerBg: rawTheme.footer_bg_color,
-        logo: rawTheme.logo_color,
-        title: rawTheme.title_color,
-        subtitle: rawTheme.subtitle_color,
-        topic: rawTheme.topic_color
-      },
-      position: {
-        header: rawTheme.header_position,
-        title: rawTheme.title_position
-      }
-    }
-  }
-
-  return {
-    entities,
-    selectedPost,
-    theme
-  }
-}
-
 Article.childContextTypes = {
   location: PropTypes.object,
   isPhotography: PropTypes.bool
@@ -486,15 +446,94 @@ Article.propTypes = {
   entities: PropTypes.object,
   match: PropTypes.object,
   selectedPost: PropTypes.object,
-  theme: constPropTypes.theme
+  styles: PropTypes.shape({
+    text: PropTypes.shape({
+      fontColor: PropTypes.string
+    }),
+    title: PropTypes.shape({
+      fontColor: PropTypes.string
+    }),
+    subtitle: PropTypes.shape({
+      fontColor: PropTypes.string
+    }),
+    topic: PropTypes.shape({
+      fontColor: PropTypes.string
+    })
+  }).isRequired,
+  isLeadingAssetFullScreen: PropTypes.bool.isRequired
 }
 
 Article.defaultProps = {
   entities: {},
   // react-router `match` object
   match: {},
-  selectedPost: {},
-  theme: constPageThemes.defaultTheme
+  selectedPost: {}
+}
+
+function chooseStyles(articleStyle) {
+  let styles = {
+    text: {
+      fontColor: colors.gray.gray25
+    },
+    title: {
+      fontColor: colors.gray.gray25
+    },
+    subtitle: {
+      fontColor: 'gray'
+    },
+    topic: {
+      fontColor: colors.primaryColor
+    }
+  }
+
+  switch(articleStyle) {
+    case themesConst.articlePage.fullscreen.dark: {
+      styles.text.fontColor = 'rgba(255, 255, 255, 0.8)'
+      styles.title.fontColor = colors.white
+      styles.subtitle.fontColor = colors.white
+      styles.topic.fontColor = colors.white
+      break
+    }
+    case themesConst.photography: {
+      styles.text.fontColor = 'rgba(255, 255, 255, 0.8)'
+      styles.title.fontColor = colors.white
+      break
+    }
+    default: {
+      break
+    }
+  }
+  return styles
+}
+
+function isLeadingAssetFullScreen(articleStyle) {
+  let isLeadingAssetFullScreen = false
+
+  switch(articleStyle) {
+    case themesConst.articlePage.fullscreen.dark:
+    case themesConst.articlePage.fullscreen.normal: {
+      isLeadingAssetFullScreen = true
+      break
+    }
+    default: {
+      break
+    }
+  }
+  return isLeadingAssetFullScreen
+}
+
+export function mapStateToProps(state) {
+  const entities = state[reduxStateFields.entities]
+  const selectedPost = state[reduxStateFields.selectedPost]
+  const post = _.get(entities, [ reduxStateFields.postsInEntities, selectedPost.slug ], {})
+  const style = post.style
+
+  return {
+    entities,
+    selectedPost,
+    styles: chooseStyles(style),
+    isLeadingAssetFullScreen: isLeadingAssetFullScreen(style)
+  }
 }
 
 export { Article }

--- a/src/managers/layout-manager.js
+++ b/src/managers/layout-manager.js
@@ -1,8 +1,40 @@
 import Footer from '@twreporter/react-components/lib/footer'
 import React from 'react'
+import styled from 'styled-components'
 import uh from '@twreporter/universal-header'
-import { themesConst } from './theme-manager'
 import { colors } from '../themes/common-variables'
+import { screen } from '../themes/screen'
+import { themesConst } from './theme-manager'
+
+const HeaderContainerWithTransparentTheme = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1;
+  ${screen.desktopBelow`
+    position: relative;
+  `}
+`
+
+const styles = {
+  normal: {
+    backgroundColor: colors.lightGray
+  },
+  photography: {
+    backgroundColor: colors.photographyColor
+  },
+  articlePage: {
+    fullscreen: {
+      dark: {
+        backgroundColor: '#2c2c2c'
+      },
+      normal: {
+        backgroundColor: colors.lightGray
+      }
+    }
+  }
+}
 
 export default class LayoutManager {
   /**
@@ -24,25 +56,50 @@ export default class LayoutManager {
   }
 
   /**
-   *  @return {string} header html markup
+   *  @return {Object} Header JSX component
    */
   getHeader() {
-    // TODO Header of topic page should be modified
-    // after the header 2.0 releases
     if (this.theme === themesConst.withoutHeader
       || this.theme === themesConst.withoutHeaderAndFooter) {
       return null
     }
+    switch(this.theme) {
+      case themesConst.withoutHeader:
+      case themesConst.withoutHeaderAndFooter: {
+        return null
+      }
+      case themesConst.articlePage.fullscreen.dark:
+      case themesConst.articlePage.fullscreen.normal: {
+        return (
+          <HeaderContainerWithTransparentTheme>
+            <uh.Header
+              theme="transparent"
+              env={this.releaseBranch}
+              isLinkExternal={false}
+            />
+          </HeaderContainerWithTransparentTheme>
+        )
+      }
+      // TODO Header of topic page should be implmeneted here, rather than in topicLandingPage container
+      //case themesConst.topicPage.fullscreen.dark:
+      //case themesConst.topicPage.fullscreen.normal: {
+      //}
+      default: {
+        return (
+          <uh.Header
+            theme={this.theme}
+            env={this.releaseBranch}
+            isLinkExternal={false}
+          />
+        )
+      }
+    }
 
-    return (
-      <uh.Header
-        theme={this.theme}
-        env={this.releaseBranch}
-        isLinkExternal={false}
-      />
-    )
   }
 
+  /**
+   * @return {Object} JSX Footer Component
+   */
   getFooter() {
     if (this.theme === themesConst.withoutHeaderAndFooter) {
       return null
@@ -56,12 +113,16 @@ export default class LayoutManager {
   getBackgroundColor() {
     switch(this.theme) {
       case themesConst.photography: {
-        return colors.photographyColor
+        return styles.photography.backgroundColor
       }
-      case themesConst.normal:
-      case themesConst.withoutHeader:
+      case themesConst.articlePage.fullscreen.dark: {
+        return styles.articlePage.fullscreen.dark.backgroundColor
+      }
+      case themesConst.articlePage.fullscreen.normal: {
+        return styles.articlePage.fullscreen.normal.backgroundColor
+      }
       default: {
-        return colors.gray.lightGray
+        return styles.normal.backgroundColor
       }
     }
   }

--- a/src/managers/theme-manager.js
+++ b/src/managers/theme-manager.js
@@ -13,7 +13,20 @@ export const themesConst = {
   normal: 'normal',
   photography: 'photography',
   withoutHeader: 'without-header',
-  withoutHeaderAndFooter: 'without-header-footer'
+  withoutHeaderAndFooter: 'without-header-footer',
+  articlePage: {
+    fullscreen: {
+      dark: 'article:fullscreen:dark',
+      normal: 'article:fullscreen:normal'
+    }
+  }
+  // TODO implement topic page theme
+  //topicPage: {
+  //  fullscreen: {
+  //    dark: 'topic:fullscreen:dark',
+  //    normal: 'topic:fullscreen:normal',
+  //  }
+  //}
 }
 
 export default class ThemeManager {
@@ -64,11 +77,16 @@ export default class ThemeManager {
         const selectedPost = reduxState[reduxStateFields.selectedPost]
         const post = _.get(entities, [ reduxStateFields.postsInEntities, selectedPost.slug ], {})
         const style = post.style
-        // photographic article page
-        if (style === themesConst.photography) {
-          return themesConst.photography
+        switch(style) {
+          case themesConst.photography:
+          case themesConst.articlePage.fullscreen.dark:
+          case themesConst.articlePage.fullscreen.normal: {
+            return style
+          }
+          default: {
+            return themesConst.normal
+          }
         }
-        return themesConst.normal
       },
       params: reduxState
     } ]


### PR DESCRIPTION
### Change Log
-  Update src/managers/theme-manager.js. Add `article:fullscreen:normal` and `article:fullscreen:dark` theme
- Update src/managers/layout-manager.js. Render different layout for `article:fullscreen:[normal|dark]` theme
- Update src/containers/Article.js
  This patch does the following changes
    - Stop using `post.theme` to  render article layout.
    - Render different article layout according to `post.style`
    - Add `isLeadingAssetFullScreen` and `styles` React Props
- Update src/components/article/layout/title-row-[above|upon].js
  Change prop `theme` to `styles` and do some design tuning
- Update src/components/article/layout/layout-maker.js.
  This patch does the following changes
  - Replace `position.title` and `position.header` by `isLeadingAssetFullScreen`
  - Render full screen image with a gray mask
  - Replace `theme` by `styles`