### PR TITLE
Send Google Analytics pageview event by url instead of pathname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- Send Google Analytics pageview event by url instead of pathname
+
 ## Release
 ### 4.1.6
 - Update job titles on about-us page

--- a/src/client.js
+++ b/src/client.js
@@ -40,7 +40,7 @@ function scrollToTopAndFirePageview() {
     }
     window.scrollTo(0, 0)
     // send Google Analytics Pageview event on route changed
-    ReactGA.pageview(window.location.pathname)
+    ReactGA.pageview(window.location.href)
   }
 
   return null
@@ -51,7 +51,7 @@ configureStore(reduxState)
     if (typeof window !== 'undefined') {
       // add Google Analytics
       ReactGA.initialize('UA-69336956-1')
-      ReactGA.set({ page: window.location.pathname })
+      ReactGA.set({ page: window.location.href })
     }
     const jsx = (
       <Provider store={store}>


### PR DESCRIPTION
This patch revises ga pageview event to send by url instead of pathname so as to avoid the ambiguity between [support|account] pathnames and [www] pathnames