### PR TITLE
Remove `hidden-print` class from Embedded component

### DIFF
--- a/src/components/article/Embedded.js
+++ b/src/components/article/Embedded.js
@@ -78,7 +78,7 @@ export class EmbeddedCode extends React.PureComponent {
     const content = _.get(this.props, [ 'content', 0 ], {})
 
     return (
-      <div className={classNames(commonStyles['inner-block'], 'hidden-print')}>
+      <div className={classNames(commonStyles['inner-block'])}>
         <div ref={div => {this.embedded = div}} dangerouslySetInnerHTML={{ __html: content.embeddedCodeWithoutScript }}/>
         <div className={classNames(commonStyles['desc-text-block'], 'text-justify')}>{content.caption}</div>
       </div>


### PR DESCRIPTION
[KanbanFlow Card](https://kanbanflow.com/t/3Nk9smUx)

This patch removes `hidden-print` class from Embedded component for
printing graphs created by narwhale