### PR TITLE
Revert "Resolve modules from the `node_modules` of this repo firstly"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### 4.3.1
+- Revert "Resolve modules from the `node_modules` of this repo firstly" for Webpack
 - Not to import all modules from `@twreporter/universal-header`
 
 ## Release

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,9 +62,6 @@ const webpackConfig = {
     host: webpackDevServerHost,
     port: webpackDevServerPort
   },
-  resolve: {
-    modules: [ path.resolve(__dirname, 'node_modules'), 'node_modules' ]
-  },
   module: {
     rules: [
       {


### PR DESCRIPTION
The purpose of the original commit is to prevent webpack-dev-server to take the node_modules in its dependencies when using yarn link. But it will cause webpack taking wrong package if there are different version of the same packge be installed.