### PR TITLE
Update make scripts and git hooks for yalc to replace yarn link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 
+# yalc
+.yalc
+
 bundle.js
 node_modules/
 static/main.js

--- a/Makefile
+++ b/Makefile
@@ -77,4 +77,21 @@ clean:
 build-babelrc:
 	@build .babelrc depends on the NODE_ENV and RENDER_ENV
 
-.PHONY: help clean build start stop dev test ui-test
+# Use Yalc to manage packages linking
+# https://github.com/whitecolor/yalc#usage
+
+link-packages:
+	@echo "Yalc add all @twreporter packages"
+	yalc add @twreporter/react-components
+	yalc add @twreporter/react-article-components
+	yalc add @twreporter/redux
+	yalc add @twreporter/core
+	yalc add @twreporter/universal-header
+	yarn
+
+unlink-packages:
+	@echo "Yalc remove all @twreporter packages"
+	yalc remove --all
+	yarn install --force
+
+.PHONY: help clean build start stop dev test ui-test link-packages unlink-packages

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 [![Join the chat at https://gitter.im/twreporter/twreporter-react](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/twreporter/twreporter-react?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 # TW Reporter
+
 New Media foundation in Taiwan.
 
 # Contains
+
 - [x] [PWA](https://developers.google.com/web/progressive-web-apps/)
 - [x] [Webpack](https://webpack.github.io)
 - [x] [Babel](https://babeljs.io/)
@@ -17,18 +19,33 @@ New Media foundation in Taiwan.
 - [x] Code splitting
 
 # Environment
+
 Install node(https://nodejs.org/en/) @7.9.0 above.
 
 # Installation
+
 `yarn install`
 
 # Production start
+
 `make start`
 
 # Development start
+
 `make dev`
 
+## Package linking management
+
+We use [`yalc`](https://github.com/whitecolor/yalc) to manage the package linking.
+
+For example, if we want to test WIP `@twreporter/react-article-components` in `twreporter-react`, the workflow will be:
+
+1. At `twreporter-npm-packages/packages/react-article-components`, run `yalc publish`
+2. At `twreporter-react`, run `yalc add @twreporter/react-article-components`. The `yalc` will copy the files in `twreporter-npm-packages/packages/react-article-components` to `twreporter-react/.yalc` and `twreporter/node_modules`. It will only take files as if we publish with `npm publish`. And `yalc` will inject the linked package hash into `twreporter-react/packages.json`, so we can know we are using developing packages.
+3. After tested okay, we can use `yalc remove --all` at `twreporter-react` to remove all files and injection in `twreporter-react`
+
 # Build docker image
+
 ```
 // install dependencies first
 yarn install
@@ -58,5 +75,6 @@ make ui-test
 ```
 
 # License
+
 * Copyright (C) 2015 - 2018 The Reporter 報導者. All rights reserved.
 * Distributed under the GNU AGPL v3.0

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "stop": "make stop",
     "test": "echo \"All unit tests are moved to dependencies.\"",
     "ui-test": "make ui-test",
-    "validate": "npm ls"
+    "validate": "npm ls",
+    "yalc-check": "yalc check"
   },
   "repository": {
     "type": "git",
@@ -124,5 +125,7 @@
     "lint",
     "test"
   ],
-  "pre-push": []
+  "pre-push": [
+    "yalc-check"
+  ]
 }

--- a/src/express/server.js
+++ b/src/express/server.js
@@ -1,4 +1,4 @@
-/*eslint no-console: 0*/
+/* global __DEVELOPMENT__ */
 import 'babel-polyfill'
 import Compression from 'compression'
 import Express from 'express'
@@ -192,7 +192,9 @@ class ExpressServer {
     this.__applyDefaultMiddlewares(options.cookieSecret)
     this.__applyStaticRoutes()
     this.__applyResponseHeader()
-    this.__applyServiceWorkerRoutes()
+    if (!__DEVELOPMENT__) {
+      this.__applyServiceWorkerRoutes()
+    }
     this.__applySearchEngineRoutes()
     this.__applyHealthCheckRoutes()
     this.__applyAppRoutes(webpackAssets, loadableStats, options)
@@ -207,12 +209,12 @@ class ExpressServer {
     if (port) {
       this.server.listen(port, (err) => {
         if (err) {
-          console.error(err)
+          console.error(err) // eslint-disable-line no-console
         }
-        console.info('==> 💻  Open http://%s:%s in a browser to view the app.', host, port)
+        console.info('==> 💻  Open http://%s:%s in a browser to view the app.', host, port) // eslint-disable-line no-console
       })
     } else {
-      console.error('==>     ERROR: No PORT environment variable has been specified')
+      console.error('==>     ERROR: No PORT environment variable has been specified') // eslint-disable-line no-console
     }
   }
 }


### PR DESCRIPTION
- Do not serve service-worker on dev (the express.js will `stat` the `sw.js` file, but we won't build it when dev) 
- Add `make link-packages` and `make unlink-packages`
- Update webpack config to use yarn link without errors (To prevent webpack take the `react`, `redux`... etc moudles from `node_modules` in linked package. Ex: Taking `react-redux` from `@twreporter/redux/node_modules/react-redux`)