### PR TITLE
`ReactGA.OutboundLink` -> `@twreporter/react-components/lib/donation-link-with-utm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 ### 4.3.10
+#### Donation Link with utm
+- `ReactGA.OutboundLink` -> `@twreporter/react-components/lib/donation-link-with-utm` 
+
 #### Bug fix
 - Remove static folder from `.dockerignore` file
 

--- a/src/components/Sponsor.js
+++ b/src/components/Sponsor.js
@@ -1,6 +1,6 @@
+import DonationLink from '@twreporter/react-components/lib/donation-link-with-utm'
 import React from 'react'
 import { SPONSOR_TITLE, SPONSOR_TEXT, SPONSOR_BUTTON } from '../constants/sponsor'
-import { donatePath } from '../constants/index'
 import map from 'lodash/map'
 import classNames from 'classnames'
 import styles from './Sponsor.scss'
@@ -30,7 +30,7 @@ class Sponsor extends React.Component {
         <div className={boxClasses}>
           <div className={styles['sponsor-title']}>{SPONSOR_TITLE}</div>
           <div className={textClasses}>{_.map(SPONSOR_TEXT, (text,index) => <p key={index}>{text}</p>) }</div>
-          <a href={donatePath} target="_blank" className={buttonClasses}>{SPONSOR_BUTTON}</a>
+          <DonationLink utmMedium="author"><span className={buttonClasses}>{SPONSOR_BUTTON}</span></DonationLink>
         </div>
       </div>)
   }

--- a/src/components/about-us/opening/anchors-panel.js
+++ b/src/components/about-us/opening/anchors-panel.js
@@ -8,6 +8,7 @@ import { screen } from '../utils/screen'
 import { SITE_META } from '../constants/data/index'
 import { storageUrlPrefix } from '../utils/config'
 import anchorlist from '../constants/data/sidebar-anchor'
+import DonationLink from '@twreporter/react-components/lib/donation-link-with-utm'
 import hrefs from '../constants/data/sidebar-link'
 import Link from 'react-router-dom/Link'
 import logo from '../../../../static/asset/about-us/Thereporter-logo-mono-white.png'
@@ -256,9 +257,11 @@ class AnchorsPanel extends React.PureComponent {
               {Anchors}
             </AnchorsContainer>
             <Icons>
-              <a href={hrefs.donate} target="_blank">
+              <DonationLink
+                utmMedium="about-us"
+              >
                 <img src={`${replaceGCSUrlOrigin(`${storageUrlPrefix}/sidebar-icon1-white.png`)}`} />
-              </a>
+              </DonationLink>
               <a href={hrefs.subscribe} target="_blank">
                 <img src={`${replaceGCSUrlOrigin(`${storageUrlPrefix}/sidebar-icon2-white.png`)}`} />
               </a>

--- a/src/components/shared/DonationBox.js
+++ b/src/components/shared/DonationBox.js
@@ -1,8 +1,7 @@
 import { colors, typography } from '../../themes/common-variables'
-import { donatePath } from '../../constants/index'
 import { screen } from '../../themes/screen'
+import DonationLink from '@twreporter/react-components/lib/donation-link-with-utm'
 import React, { PureComponent } from 'react'
-import ReactGA from 'react-ga'
 import styled from 'styled-components'
 
 const TITLE = '用行動支持報導者'
@@ -40,7 +39,7 @@ const Title = styled.p`
 const Text = styled.p`
   font-size: ${typography.font.size.medium};
   line-height: 1.75;
-  color: ${colors.black};  
+  color: ${colors.black};
 `
 
 const Donate = styled.div`
@@ -74,10 +73,6 @@ const Donate = styled.div`
 
 export default class DonationBox extends PureComponent {
   render() {
-    let url = null
-    if (typeof window !== 'undefined') {
-      url = window.location.href
-    }
     return (
       <Container>
         <Title>
@@ -87,12 +82,11 @@ export default class DonationBox extends PureComponent {
           {TEXT}
         </Text>
         <Donate>
-          <ReactGA.OutboundLink
-            eventLabel={`[article_donation_button_click]: ${url}`}
-            to={donatePath}
-            target="_blank">
+          <DonationLink
+            utmMedium="article"
+          >
             <p>{DONATEBUTTONTEXT}</p>
-          </ReactGA.OutboundLink>
+          </DonationLink>
         </Donate>
       </Container>
     )

--- a/src/components/side-bar/aboutus-page-side-bar.js
+++ b/src/components/side-bar/aboutus-page-side-bar.js
@@ -1,12 +1,12 @@
 import { SITE_META } from '../about-us/constants/data/index'
 import { buildFbShareLink } from '../about-us/utils/build-fb-share-link'
 import { colors, typography } from '../../themes/common-variables'
-import { donatePath } from '../../constants/index'
 import { replaceGCSUrlOrigin } from '@twreporter/core/lib/utils/storage-url-processor'
 import { screen } from '../about-us/utils/screen'
 import { storageUrlPrefix } from '../about-us/utils/config'
 import anchorlist from '../about-us/constants/data/sidebar-anchor'
 import baseComponents from './base-components'
+import DonationLink from '@twreporter/react-components/lib/donation-link-with-utm'
 import hrefs from '../about-us/constants/data/sidebar-link'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -129,9 +129,11 @@ class AboutusPageSideBar extends React.PureComponent {
             currentAnchorId={currentAnchorId}
           />
           <Icons>
-            <a href={donatePath} target="_blank">
+            <DonationLink
+              utmMedium="about-us"
+            >
               <img src={`${replaceGCSUrlOrigin(`${storageUrlPrefix}/sidebar-icon1.png`)}`} />
-            </a>
+            </DonationLink>
             <a href={hrefs.subscribe} target="_blank">
               <img src={`${replaceGCSUrlOrigin(`${storageUrlPrefix}/sidebar-icon2.png`)}`} />
             </a>

--- a/src/components/topic/Header.js
+++ b/src/components/topic/Header.js
@@ -1,6 +1,7 @@
 'use strict'
 import BackToTopicIcon from '../../../static/asset/back-to-topic.svg'
 import DonationIcon from '../../../static/asset/donate.svg'
+import DonationLink from '@twreporter/react-components/lib/donation-link-with-utm'
 import Link from 'react-router-dom/Link'
 import LogoIcon from '../../../static/asset/navbar-fixed-top-logo.svg'
 import PropTypes from 'prop-types'
@@ -11,7 +12,6 @@ import WhiteLogoIcon from '../../../static/asset/logo-white-s.svg'
 import cx from 'classnames'
 import constPageThemes from '../../constants/page-themes'
 import style from './Header.scss'
-import { donatePath } from '../../constants/index'
 
 
 // TBD fixed on the top needs to be implement
@@ -47,14 +47,14 @@ export default function Header({ isFixedToTop, title }) {
 
   return (
     <div className={cx(style.container, fixedStyle)}>
-      <a href={donatePath} target="_blank" title="贊助我們">
+      <DonationLink utmMedium="topic">
         <div className={style.donation}>
           <div>
             { isFixedToTop ? <DonationIcon /> : <WhiteDonationIcon /> }
           </div>
           <span>贊助我們</span>
         </div>
-      </a>
+      </DonationLink>
       {centerJsx}
       {rightJsx}
     </div>


### PR DESCRIPTION
KanbanFlow Card: https://kanbanflow.com/t/mkh8MzGM

### Reason to Change
In the past, we used 貝殼放大's billing service.
Since the service was not under our domain, we couldn't install GA script to track the requests.
However, we own our donation service(https://support.twreporter.org) now; hence, we can track the requests by installing GA script in the donation pages.
By providing `utm_medium`, `utm_source` and `utm_campaign`, the editors can easily analyze the requests.
 