### PR TITLE
Fix topic description and relateds

### DIFF
--- a/src/components/topic/description/index.js
+++ b/src/components/topic/description/index.js
@@ -62,19 +62,24 @@ const TeamDescription = styled(Section)`
 
 const Description = (props) => {
   const { topicDescription, teamDescription } = props
-  if (!_.get(topicDescription, 'length') && !_.get(teamDescription, 'length')) {
-    return null
+  if (
+    (_.get(topicDescription, 'length') > 0 ||
+    _.get(topicDescription, 'content.length') > 0) &&
+    (_.get(teamDescription, 'length') > 0 ||
+    _.get(teamDescription, 'content.length') > 0)
+  ) {
+    return (
+      <Container>
+        <TopicDescription>
+          {renderTopicContent(topicDescription)}
+        </TopicDescription>
+        <TeamDescription>
+          {renderTopicContent(teamDescription)}
+        </TeamDescription>
+      </Container>
+    )
   }
-  return (
-    <Container>
-      <TopicDescription>
-        {renderTopicContent(topicDescription)}
-      </TopicDescription>
-      <TeamDescription>
-        {renderTopicContent(teamDescription)}
-      </TeamDescription>
-    </Container>
-  )
+  return null
 }
 
 Description.propTypes = {

--- a/src/containers/TopicLandingPage.js
+++ b/src/containers/TopicLandingPage.js
@@ -3,7 +3,6 @@ import { SITE_META, SITE_NAME } from '../constants/index'
 import Banner from '../components/topic/banner'
 import Description from '../components/topic/description'
 import Helmet from 'react-helmet'
-import memoizeOne from 'memoize-one'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Related from '../components/topic/related'
@@ -49,7 +48,16 @@ class TopicLandingPage extends Component {
     fetchAFullTopic(slug)
   }
 
-  _renderTopic = memoizeOne((slug) => {
+  _renderLoadingElements() {
+    /* TODO: Add loading mockup or spinner */
+    return (
+      <Container>
+        <TopicHeader />
+      </Container>
+    )
+  }
+
+  _renderTopic(slug) {
     const { entities } = this.props
     const postEntities = _.get(entities, reduxStateFields.postsInEntities, {})
     const topicEntities = _.get(entities, reduxStateFields.topicsInEntities, {})
@@ -123,7 +131,7 @@ class TopicLandingPage extends Component {
         />
       </Container>
     )
-  })
+  }
 
   render() {
     const { selectedTopic } = this.props
@@ -133,7 +141,11 @@ class TopicLandingPage extends Component {
         <SystemError error={error} />
       )
     }
-    const slug = _.get(selectedTopic, 'slug') // {string}
+    const isFetching = _.get(selectedTopic, 'isFetching', false)
+    const slug = _.get(selectedTopic, 'slug')
+    if (isFetching || !slug) {
+      return this._renderLoadingElements()
+    }
     return this._renderTopic(slug)
   }
 }


### PR DESCRIPTION
Fix bugs in 4.2.2-rc.1:
問題：
1. client side render topic landing page 的話， related posts 出不來
2. topic landing page 沒有 description 的時候，還是會出現白底紅線