### PR TITLE
Fix list isFethcing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix list isFethcing logic: If there’s only one item in a list, the previous code will regard the container as at `isFetching` status.
+
 ## Release
 
 ### 4.4.5

--- a/src/containers/Category.js
+++ b/src/containers/Category.js
@@ -40,8 +40,6 @@ class Category extends PureComponent {
   }
 
   render() {
-    let isFetching = false
-
     const {
       catId,
       catLabel,
@@ -76,23 +74,17 @@ class Category extends PureComponent {
     const pages = _.get(lists, [ catId, 'pages' ], {})
     const startPos = _.get(pages, [ page, 0 ], 0)
     const endPos = _.get(pages, [ page, 1 ], 0)
-
-    // page is provided, but not fecth yet
-    if (startPos === 0 && endPos === 0) {
-      isFetching = true
-    }
-
+  
     // denormalize the items of current page
     const posts = utils.denormalizePosts(_.get(lists, [ catId, 'items' ], []).slice(startPos, endPos + 1), postEntities)
     const postsLen = _.get(posts, 'length', 0)
+    const isFetching = postsLen === 0
     // Error handling
     const error = _.get(lists, [ catId, 'error' ], null)
     if (error !== null && postsLen === 0) {
       return (
         <SystemError error={error} />
       )
-    } else if (postsLen === 0) {
-      isFetching = true
     }
 
     const title = catLabel + SITE_NAME.SEPARATOR + SITE_NAME.FULL

--- a/src/containers/Tag.js
+++ b/src/containers/Tag.js
@@ -52,8 +52,6 @@ class Tag extends PureComponent {
   }
 
   render() {
-    let isFetching = false
-
     const {
       entities,
       lists,
@@ -89,24 +87,17 @@ class Tag extends PureComponent {
       )
     }
 
-    // page is provided, but not fecth yet
-    if (startPos === 0 && endPos === 0) {
-      isFetching = true
-    }
-
     // denormalize the items of current page
     const posts = utils.denormalizePosts(_.get(lists, [ tagId, 'items' ], []).slice(startPos, endPos + 1), postEntities)
     const postsLen = _.get(posts, 'length', 0)
+    const isFetching = postsLen === 0
 
     // Error handling
     if (error !== null && postsLen === 0) {
       return (
         <SystemError error={error} />
       )
-    } else if (postsLen === 0) {
-      isFetching = true
     }
-
     const tagName = this._findTagName(_.get(posts, [ 0, 'tags' ]), tagId)
     const canonical = `${SITE_META.URL}tag/${tagId}`
     const title = tagName + SITE_NAME.SEPARATOR + SITE_NAME.FULL


### PR DESCRIPTION
If there’s only one item in a list, the current code will regard it to be at `isFetching` status.