### PR TITLE
Bug fixes of v4.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 ## Unreleased
 
-- Fix list isFethcing logic: If there’s only one item in a list, the previous code will regard the container as at `isFetching` status.
-
 ## Release
+
+### 4.4.6
+
+#### Bug Fixes
+
+- Fix list isFethcing logic: If there’s only one item in a list, the previous code will regard the container as at `isFetching` status.
+- Fix wrong componentDidUpdate arguments: `nextProps` -> `prevProps`
+- Remove PM2 in comments
+
+#### Commits
+
+5e21c088 Remove PM2 in comments
+1b0b7e1e Fix wrong componentDidUpdate arguments
+ec45c064 Fix list isFethcing logic
 
 ### 4.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### 4.4.6
 
-#### Bug Fixes
+#### Notable Changes
+
+##### Bug Fixes
 
 - Fix list isFethcing logic: If there’s only one item in a list, the previous code will regard the container as at `isFetching` status.
 - Fix wrong componentDidUpdate arguments: `nextProps` -> `prevProps`
@@ -12,19 +14,21 @@
 
 #### Commits
 
-5e21c088 Remove PM2 in comments
-1b0b7e1e Fix wrong componentDidUpdate arguments
-ec45c064 Fix list isFethcing logic
+- [[5e21c088](https://github.com/twreporter/twreporter-react/commit/5e21c088)] Remove PM2 in comments (yucj)
+- [[1b0b7e1e](https://github.com/twreporter/twreporter-react/commit/1b0b7e1e)] Fix wrong componentDidUpdate arguments (yucj)
+- [[ec45c064](https://github.com/twreporter/twreporter-react/commit/ec45c064)] Fix list isFethcing logic (yucj)
 
 ### 4.4.5
 
-#### Bug Fixes
+#### Notable Changes
+
+##### Bug Fixes
 
 - Fix home spinner displayed logic
 - Fix wrong query retrieving with react-router. After this fix, the page being visited will be documented in url as `?page=<number>` for `Tag`, `Topics`, and `Categories`.
   - Add query validator to prevent invalid search query page input
 
-#### Upgrade Dependencies
+##### Upgrade Dependencies
 
 - `@twreporter/velocity-react@^1.4.2` -> `velocity-react@^1.4.3`
 - `react-transition-group@^1.2.1` -> `^2.0.0`
@@ -37,14 +41,14 @@ ec45c064 Fix list isFethcing logic
 
 #### Commits
 
-- 400c6d0e Prevent invalid search query page input
-- efccfe95 Fix wrong query retrieving with react-router
-- 66025c35 Fix home spinner displayed logic
-- 9052908c Fix mock post content
-- de3a1dd8 Per file imports are deprecated for react-router-dom
-- 1357d17e Upgrade react-transition-group to v2
-- b1ca418e Replace customized velocity-react with original one
-- dd71feec Remove deprecated `componentWillMount` and `componentWillReceiveProps`
+- [[400c6d0e](https://github.com/twreporter/twreporter-react/commit/400c6d0e)] Prevent invalid search query page input (yucj)
+- [[efccfe95](https://github.com/twreporter/twreporter-react/commit/efccfe95)] Fix wrong query retrieving with react-router (yucj)
+- [[66025c35](https://github.com/twreporter/twreporter-react/commit/66025c35)] Fix home spinner displayed logic (yucj)
+- [[9052908c](https://github.com/twreporter/twreporter-react/commit/9052908c)] Fix mock post content (yucj)
+- [[de3a1dd8](https://github.com/twreporter/twreporter-react/commit/de3a1dd8)] Per file imports are deprecated for react-router-dom (yucj)
+- [[1357d17e](https://github.com/twreporter/twreporter-react/commit/1357d17e)] Upgrade react-transition-group to v2 (yucj)
+- [[b1ca418e](https://github.com/twreporter/twreporter-react/commit/b1ca418e)] Replace customized velocity-react with original one (yucj)
+- [[dd71feec](https://github.com/twreporter/twreporter-react/commit/dd71feec)] Remove deprecated `componentWillMount` and `componentWillReceiveProps` (yucj)
 
 ### 4.4.4
 - Disable DLC and remove redundant steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix list isFethcing logic: If there’s only one item in a list, the previous code will regard the container as at `isFetching` status.
+
 ## Release
 
 ### 4.4.5

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build-server:
 build: clean build-webpack build-service-worker build-server
 
 start-server:
-	@echo "\033[33m[PM2]\033[0m start application server"
+	@echo "\033[33m[NODE]\033[0m start application server"
 	NODE_ENV=$(PROD_NODE_ENV) node dist/server.js
 
 start: build start-server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "4.4.5",
+  "version": "4.4.6",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",

--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -69,12 +69,12 @@ class Article extends PureComponent {
     window.removeEventListener('scroll', this.handleScroll)
   }
 
-  componentDidUpdate(nextProps) {
-    const { match } = nextProps
-    const slug = _.get(match, 'params.slug')
-    const isFetching = _.get(nextProps, 'selectedPost.isFetching') || _.get(this.props, 'selectedPost.isFetching')
-    if (slug !== _.get(this.props, 'selectedPost.slug') && !isFetching) {
-      this.props.fetchAFullPost(slug)
+  componentDidUpdate(prevProps) {
+    const { match } = this.props
+    const slugInParams = _.get(match, 'params.slug')
+    const isFetching = _.get(this.props, 'selectedPost.isFetching')
+    if (slugInParams !== _.get(prevProps, 'selectedPost.slug') && !isFetching) {
+      this.props.fetchAFullPost(slugInParams)
     }
   }
 

--- a/src/containers/Category.js
+++ b/src/containers/Category.js
@@ -40,8 +40,6 @@ class Category extends PureComponent {
   }
 
   render() {
-    let isFetching = false
-
     const {
       catId,
       catLabel,
@@ -76,23 +74,17 @@ class Category extends PureComponent {
     const pages = _.get(lists, [ catId, 'pages' ], {})
     const startPos = _.get(pages, [ page, 0 ], 0)
     const endPos = _.get(pages, [ page, 1 ], 0)
-
-    // page is provided, but not fecth yet
-    if (startPos === 0 && endPos === 0) {
-      isFetching = true
-    }
-
+  
     // denormalize the items of current page
     const posts = utils.denormalizePosts(_.get(lists, [ catId, 'items' ], []).slice(startPos, endPos + 1), postEntities)
     const postsLen = _.get(posts, 'length', 0)
+    const isFetching = postsLen === 0
     // Error handling
     const error = _.get(lists, [ catId, 'error' ], null)
     if (error !== null && postsLen === 0) {
       return (
         <SystemError error={error} />
       )
-    } else if (postsLen === 0) {
-      isFetching = true
     }
 
     const title = catLabel + SITE_NAME.SEPARATOR + SITE_NAME.FULL

--- a/src/containers/Tag.js
+++ b/src/containers/Tag.js
@@ -52,8 +52,6 @@ class Tag extends PureComponent {
   }
 
   render() {
-    let isFetching = false
-
     const {
       entities,
       lists,
@@ -89,24 +87,17 @@ class Tag extends PureComponent {
       )
     }
 
-    // page is provided, but not fecth yet
-    if (startPos === 0 && endPos === 0) {
-      isFetching = true
-    }
-
     // denormalize the items of current page
     const posts = utils.denormalizePosts(_.get(lists, [ tagId, 'items' ], []).slice(startPos, endPos + 1), postEntities)
     const postsLen = _.get(posts, 'length', 0)
+    const isFetching = postsLen === 0
 
     // Error handling
     if (error !== null && postsLen === 0) {
       return (
         <SystemError error={error} />
       )
-    } else if (postsLen === 0) {
-      isFetching = true
     }
-
     const tagName = this._findTagName(_.get(posts, [ 0, 'tags' ]), tagId)
     const canonical = `${SITE_META.URL}tag/${tagId}`
     const title = tagName + SITE_NAME.SEPARATOR + SITE_NAME.FULL


### PR DESCRIPTION
## Bug Fixes

- Fix list isFethcing logic: If there’s only one item in a list, the previous code will regard the container as at `isFetching` status.
- Fix wrong componentDidUpdate arguments: `nextProps` -> `prevProps`
- Remove PM2 in comments