### PR TITLE
Fix kubeconfig missing zone or regional info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,13 @@ jobs:
               # change ${GOOGLE_PREVIEW_CLUSTER_NAME} -> ${K8S_CLUSTER_NAME}
               gcloud --quiet config set compute/zone asia-east1-a
               CLUSTER_NAME=${GOOGLE_PREVIEW_CLUSTER_NAME}
+              gcloud --quiet container clusters get-credentials $CLUSTER_NAME
             fi
 
             if [ "${CIRCLE_BRANCH}" == "staging" ] || [ "${CIRCLE_BRANCH}" == "next" ]; then
               gcloud --quiet config set compute/region asia-east1
               CLUSTER_NAME=${K8S_CLUSTER_NAME}
+              gcloud --quiet container clusters get-credentials $CLUSTER_NAME --region=asia-east1
             fi
 
             if [ "${CIRCLE_BRANCH}" == "release" ]; then
@@ -91,10 +93,8 @@ jobs:
               # change ${GOOGLE_CLUSTER_NAME} -> ${K8S_CLUSTER_NAME}
               gcloud --quiet config set compute/zone asia-east1-a
               CLUSTER_NAME=${GOOGLE_CLUSTER_NAME}
+              gcloud --quiet container clusters get-credentials $CLUSTER_NAME
             fi
-
-            echo "CLUSTER_NAME: ${CLUSTER_NAME}"
-            gcloud --quiet container clusters get-credentials $CLUSTER_NAME
 
       - run:
           name: Build, push and deploy Docker image


### PR DESCRIPTION
This patch fixes the kubeconfig generated by gcloud CLI which does not
inherit from default compute/region config.