### PR TITLE
[hotfix] Fix og-image type error on topic landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+[Bug] Fix og-image type error on topic landing page
+
 ## Release
 
 ### 4.4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 ## Unreleased
 
-[Bug] Fix og-image type error on topic landing page
-
 ## Release
+
+### 4.4.7
+
+#### Notable Changes
+
+##### Bug Fixes
+
+- [Bug] Fix og-image type error on topic landing page
+
+#### Commits
+
+- [[802e69f](https://github.com/twreporter/twreporter-react/commit/802e69fa495e643dd4a03da9e43d690c2d9b3f4e)] - Fix og-image type error on topic landing page (taylrj)
+- [[a89fb28](https://github.com/twreporter/twreporter-react/commit/a89fb282afd7a47948d705b4d17dbf3ae401bb1f)] - Add `leading-image` as the fallback `og-image` on topic landing page (taylrj)
 
 ### 4.4.6
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "4.4.6",
+  "version": "4.4.7",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",

--- a/src/containers/TopicLandingPage.js
+++ b/src/containers/TopicLandingPage.js
@@ -89,7 +89,7 @@ class TopicLandingPage extends Component {
     const teamDescription = _.get(topic, 'team_description.api_data', [])
     const ogDescription =  _.get(topic, 'og_description', '') || SITE_META.DESC
     const ogTitle = _.get(topic, 'og_title', '') || _.get(topic, 'title', '')
-    const ogImageUrl = _.get(topic, 'og_image.resized_targets.tablet.url')
+    const ogImageUrl = _.get(topic, 'og_image.resized_targets.tablet.url') || _.get(topic, 'leading_image.resized_targets.tablet.url') 
     const publishedDate = _.get(topic, 'published_date', '')
 
     const canonical = `${SITE_META.URL}topics/${slug}`

--- a/src/containers/TopicLandingPage.js
+++ b/src/containers/TopicLandingPage.js
@@ -89,6 +89,7 @@ class TopicLandingPage extends Component {
     const teamDescription = _.get(topic, 'team_description.api_data', [])
     const ogDescription =  _.get(topic, 'og_description', '') || SITE_META.DESC
     const ogTitle = _.get(topic, 'og_title', '') || _.get(topic, 'title', '')
+    const ogImageUrl = _.get(topic, 'og_image.resized_targets.tablet.url')
     const publishedDate = _.get(topic, 'published_date', '')
 
     const canonical = `${SITE_META.URL}topics/${slug}`
@@ -104,11 +105,11 @@ class TopicLandingPage extends Component {
             { name: 'description', content: ogDescription },
             { name: 'twitter:title', content: fullTitle },
             { name: 'twitter:description', content: ogDescription },
-            { name: 'twitter:image', content: og_image },
+            { name: 'twitter:image', content: ogImageUrl },
             { name: 'twitter:card', content: 'summary_large_image' },
             { property: 'og:title', content: fullTitle },
             { property: 'og:description', content: ogDescription },
-            { property: 'og:image', content: og_image },
+            { property: 'og:image', content: ogImageUrl },
             { property: 'og:type', content: 'website' },
             { property: 'og:url', content: canonical },
             { property: 'og:rich_attachment', content: 'true' }


### PR DESCRIPTION
This patch fixes og-image type error where should be an url string
rather than `predefinedPropTypes.imgObj`