### PR TITLE
chore: fix missing namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
 
             if [ "${CIRCLE_BRANCH}" == "release" ]; then
               PKG_VER="$(cat .pkg-version)"
+              CLUSTER_NAMESPACE="production"
               ENVIRONMENT="release"
             fi
 


### PR DESCRIPTION
This patch fixes the missing namespace of the GKE deployment in the
release environment.