### PR TITLE
Handle conditional requests

### DIFF
--- a/src/constants/status-code.js
+++ b/src/constants/status-code.js
@@ -1,6 +1,7 @@
 export default {
   ok: 200,
   created: 201,
+  movedPermanently: 301,
   badRequest: 400,
   unauthorized: 401,
   forbidden: 403,

--- a/src/express/server.js
+++ b/src/express/server.js
@@ -99,8 +99,8 @@ class ExpressServer {
 
   __applyResponseHeader() {
     this.app.use(function (req, res, next) {
-      res.header('Access-Control-Allow-Origin', 'https://www.twreporter.org/')
-      res.header('Access-Control-Allow-Headers', 'X-Requested-With')
+      res.set('Access-Control-Allow-Origin', 'https://www.twreporter.org/')
+      res.set('Access-Control-Allow-Headers', 'X-Requested-With')
       next()
     })
   }
@@ -161,10 +161,10 @@ class ExpressServer {
           const idToken = _.get(req, 'cookies.id_token')
           if (idToken) {
             // not to cache personal response
-            res.header('Cache-Control', 'no-store')
+            res.set('Cache-Control', 'no-store')
           } else {
             // set Cache-Control header for caching
-            res.header('Cache-Control', 'public, max-age=300')
+            res.set('Cache-Control', 'public, max-age=300')
           }
         }
 
@@ -185,7 +185,7 @@ class ExpressServer {
         return next(err)
       }
 
-      res.header('Cache-Control', 'no-store')
+      res.set('Cache-Control', 'no-store')
       if (_.get(err, 'statusCode') === 404) {
         res.redirect('/error/404')
       } else {

--- a/src/routes.js
+++ b/src/routes.js
@@ -216,13 +216,13 @@ export default function getRoutes() {
         // there is no `staticContext` on the client,
         // so we need to guard against that here
         if (staticContext) {
-          staticContext.statusCode = 404
+          staticContext.statusCode = statusCodeConst.notFound
         }
 
         return (
           <SystemError
             error={{
-              statusCode: 404
+              statusCode: statusCodeConst.notFound
             }}
           />
         )


### PR DESCRIPTION
### Change Reason
Even though we set `Cache-Control: public, max-age:300` in response header,
the service worker would use **Network falling back to cache** policy (see https://github.com/twreporter/twreporter-react/blob/master/service-worker/service-worker.tmpl#L42-L50) to fetch the resource from network, and fallback to browser cache if request fails.

This policy will make server facing much more requests than we thought.
Therefore, the server needs to handle conditional requests.
Conditional requests make server not to send body payload back to browsers if the response body is the same as the last time response. 

### Background Information
The reason service worker uses **Network falling back to cache policy** is because we want to reflect the resource change as soon as possible.
We can have another thread to discuss what kind of policy we should use. (See https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook#serving-suggestions)