### PR TITLE
chore: update version to v4.4.20-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## 4.4.20
+## 4.4.20-rc.0
 
 ### Notable Changes
 
 - fix: section 2 of about us
   - fix section2 where arrows of photography department can not click 
 
+### Commits
 * [[`334ea8e794`](https://github.com/twreporter/twreporter-react/commit/334ea8e794)] - **fix**: section 2 of about us (Taylor Fang)
 
 ## 4.4.19

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "4.4.20",
+  "version": "4.4.20-rc.0",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",


### PR DESCRIPTION
This patch update version to v4.4.20-rc.0 since v4.4.20 is not ready
to release yet.