### PR TITLE
fix: prevent dev env from error reorting

### DIFF
--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -62,7 +62,14 @@ function loggerFactory() {
 
   factory.makeExpressMiddleware = () => {
     const logger = factory.getLogger()
-    return makeExpressMiddleware(logger)
+    if (globalEnv.isProduction) {
+      return makeExpressMiddleware(logger)
+    }
+
+    return Promise.resolve((req, res, next) => {
+      logger.info(req.url)
+      next()
+    })
   }
 
   return factory


### PR DESCRIPTION
`logging-winston.express.makeMiddleware` will send development
environment logs onto GCP Logging system if local workspace has been
authenticated by gcloud.

Hence, we only run `makeMiddleware` in production environment.