### PR TITLE
refactor: use memoize-one to avoid re-rendering

### DIFF
--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -8,6 +8,7 @@ import ReadingProgress from '../components/article/reading-progress'
 import SystemError from '../components/SystemError'
 import bsConst from '../constants/browser-storage'
 import localForage from 'localforage'
+import memoizeOne from 'memoize-one'
 import siteMeta from '../constants/site-meta'
 import twreporterRedux from '@twreporter/redux'
 import uiManager from '../managers/ui-manager'
@@ -332,6 +333,22 @@ const {
  *  @typedef {import('../utils/shallow-clone-entity').MetaOfPost} MetaOfPost
  */
 
+const arePostsIdAndFullEqual = (newArgs, lastArgs) => {
+  const post1 = _.get(newArgs, 0, null)
+  const post2 = _.get(lastArgs, 0, null)
+  if (post1 && post2) {
+    if (post1.id === post2.id && post1.full === post2.full) {
+      return true
+    }
+  }
+  return false
+}
+
+const memoizeShallowCloneFullPost = memoizeOne(
+  cloneUtils.shallowCloneFullPost,
+  arePostsIdAndFullEqual
+)
+
 /**
  *  This function returns a post which is cloned from entities state.
  *  @param {ReduxState} state
@@ -340,7 +357,7 @@ const {
  */
 function postProp(state, id) {
   const post = _.get(state, [entities, postsInEntities, 'byId', id], null)
-  return cloneUtils.shallowCloneFullPost(post)
+  return memoizeShallowCloneFullPost(post)
 }
 
 /**

--- a/src/containers/TopicLandingPage.js
+++ b/src/containers/TopicLandingPage.js
@@ -9,6 +9,7 @@ import loggerFactory from '../logger'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Related from '../components/topic/related'
+import memoizeOne from 'memoize-one'
 import siteMeta from '../constants/site-meta'
 import styled from 'styled-components'
 import SystemError from '../components/SystemError'
@@ -272,6 +273,22 @@ const {
  *  @typedef {import('../utils/shallow-clone-entity').MetaOfPost} MetaOfPost
  */
 
+const areTopicsIdAndFullEqual = (newArgs, lastArgs) => {
+  const topic1 = _.get(newArgs, 0, null)
+  const topic2 = _.get(lastArgs, 0, null)
+  if (topic1 && topic2) {
+    if (topic1.id === topic2.id && topic1.full === topic2.full) {
+      return true
+    }
+  }
+  return false
+}
+
+const memoizeShallowCloneFullTopic = memoizeOne(
+  cloneUtils.shallowCloneFullTopic,
+  areTopicsIdAndFullEqual
+)
+
 /**
  *  This function returns a topic which is cloned from entities state.
  *  @param {ReduxState} state
@@ -280,7 +297,7 @@ const {
  */
 function topicProp(state, id) {
   const topic = _.get(state, [entities, topicsInEntities, 'byId', id], null)
-  return cloneUtils.shallowCloneFullTopic(topic)
+  return memoizeShallowCloneFullTopic(topic)
 }
 
 /**


### PR DESCRIPTION
In this patch, we use memoize-one to avoid
re-shallowCloning (fullTopic|fullPost).

It helps to avoid re-rendering article page body
and topic landing page body if end users just click load more related
articles button.