### PR TITLE
refactor: do not cache response for preview branch and update service worker runtime cache pattern

### DIFF
--- a/service-worker/service-worker-generator.js
+++ b/service-worker/service-worker-generator.js
@@ -93,7 +93,7 @@ const param = {
   swToolBoxCode: swToolBoxCode,
   runtimeCaching: generateRuntimeCaching([
     {
-      urlPattern: new RegExp(apiURLPrefix + '/v1/posts'),
+      urlPattern: new RegExp(apiURLPrefix + '/v2/posts'),
       handler: 'networkFirst',
       options: {
         cache: {
@@ -103,7 +103,7 @@ const param = {
       },
     },
     {
-      urlPattern: new RegExp(apiURLPrefix + '/v1/topics'),
+      urlPattern: new RegExp(apiURLPrefix + '/v2/topics'),
       handler: 'networkFirst',
       options: {
         cache: {
@@ -113,7 +113,7 @@ const param = {
       },
     },
     {
-      urlPattern: new RegExp(apiURLPrefix + '/v1/index_page(_categories)?'),
+      urlPattern: new RegExp(apiURLPrefix + '/v2/index_page'),
       handler: 'networkFirst',
       options: {
         cache: {

--- a/src/constants/status-code.js
+++ b/src/constants/status-code.js
@@ -1,6 +1,7 @@
 export default {
   ok: 200,
   created: 201,
+  movedPermanently: 301,
   found: 302,
   badRequest: 400,
   unauthorized: 401,


### PR DESCRIPTION
### Change Reason
Editors report that preview server (keystone-preview.twreporter.org) didn't show the latest content after modifying it in the keystone-editor.

After digging out, I guess the reason is the content is cached by browser.
Therefore, we remove `Cache-Control: public, max-age=300` response header for preview server.