### PR TITLE
fix: render stale data due to wrong memoize function

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@twreporter/index-page": "1.0.9",
     "@twreporter/react-article-components": "^1.2.3",
     "@twreporter/react-components": "^8.3.1",
-    "@twreporter/redux": "^7.0.1",
+    "@twreporter/redux": "7.0.2-rc.0",
     "@twreporter/universal-header": "^2.1.6",
     "axios": "^0.19.0",
     "babel-polyfill": "^6.26.0",

--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -333,21 +333,7 @@ const {
  *  @typedef {import('../utils/shallow-clone-entity').MetaOfPost} MetaOfPost
  */
 
-const arePostsIdAndFullEqual = (newArgs, lastArgs) => {
-  const post1 = _.get(newArgs, 0, null)
-  const post2 = _.get(lastArgs, 0, null)
-  if (post1 && post2) {
-    if (post1.id === post2.id && post1.full === post2.full) {
-      return true
-    }
-  }
-  return false
-}
-
-const memoizeShallowCloneFullPost = memoizeOne(
-  cloneUtils.shallowCloneFullPost,
-  arePostsIdAndFullEqual
-)
+const memoizeShallowCloneFullPost = memoizeOne(cloneUtils.shallowCloneFullPost)
 
 /**
  *  This function returns a post which is cloned from entities state.

--- a/src/containers/TopicLandingPage.js
+++ b/src/containers/TopicLandingPage.js
@@ -273,20 +273,8 @@ const {
  *  @typedef {import('../utils/shallow-clone-entity').MetaOfPost} MetaOfPost
  */
 
-const areTopicsIdAndFullEqual = (newArgs, lastArgs) => {
-  const topic1 = _.get(newArgs, 0, null)
-  const topic2 = _.get(lastArgs, 0, null)
-  if (topic1 && topic2) {
-    if (topic1.id === topic2.id && topic1.full === topic2.full) {
-      return true
-    }
-  }
-  return false
-}
-
 const memoizeShallowCloneFullTopic = memoizeOne(
-  cloneUtils.shallowCloneFullTopic,
-  areTopicsIdAndFullEqual
+  cloneUtils.shallowCloneFullTopic
 )
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,10 +518,10 @@
     smoothscroll "^0.3.0"
     styled-components "^4.0.0"
 
-"@twreporter/redux@^7.0.0", "@twreporter/redux@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@twreporter/redux/-/redux-7.0.1.tgz#2208b68bf7eccc8f70990371cc24794d08d93e3d"
-  integrity sha512-NwBvS7kmF38nJWc4ecFaUV+fdYs7YAH2Uv1596SrBYsI6sD7E3ZxwoA4uY/COzNT8Mcki2pKksCXyFfmLSk/Ew==
+"@twreporter/redux@^7.0.0", "@twreporter/redux@7.0.2-rc.0":
+  version "7.0.2-rc.0"
+  resolved "https://registry.yarnpkg.com/@twreporter/redux/-/redux-7.0.2-rc.0.tgz#bf010428ab78ba350b60d1aed84f7f6b50d79aec"
+  integrity sha512-pwGKg4C0746FcWPuOmgLUakTqS608cMdEJQ43wmad0XoVyF8LRyx9+4m32wGP3et6nyHGBFFaS/6d8jzCGF4vA==
   dependencies:
     axios "^0.19.0"
     es6-error "^4.0.2"
@@ -3228,7 +3228,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.11.0, es-abstract@^1.17.0, es-abstract@^1.17.5, es-abstract@^1.7.0:
+es-abstract@^1.11.0, es-abstract@^1.17.0, es-abstract@^1.17.5:
   version "1.17.6"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
   integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
@@ -3245,7 +3245,7 @@ es-abstract@^1.11.0, es-abstract@^1.17.0, es-abstract@^1.17.5, es-abstract@^1.7.
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
-es-to-primitive@^1.2.0, es-to-primitive@^1.2.1:
+es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
   integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
@@ -3795,11 +3795,6 @@ extract-zip@^1.6.6:
     debug "2.6.9"
     mkdirp "0.5.1"
     yauzl "2.4.1"
-
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"
@@ -5074,7 +5069,7 @@ is-redirect@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
-is-regex@^1.0.4, is-regex@^1.1.0:
+is-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==


### PR DESCRIPTION
### Change Reason
In memoize function,
we check `prevPost.id === nextPost.id` and
`prevPost.full === nextPost.full`,
if true, memoize will use the cached post object.

However, that condition makes memoize to return the stale post object.
For example, if editor edits the post object, such as changing the post title,
that change won't make the memoize function to return a new post object.
Therefore, Article page will render the stale data.

### Related PR
[refactor: stop using lodash.merge in entities reducer #150
](https://github.com/twreporter/twreporter-npm-packages/pull/150)

The reason why we use `arePostsIdAndFullEqual` and `areTopicsIdAndFullEqual` is
`redux.entities.posts` and `redux.entities.topics` change all the time.
And that change will cause Article page re-render.
In the [above PR](https://github.com/twreporter/twreporter-npm-packages/pull/150), it stops changing `redux.entities.posts` and `redux.entities.topics` if there is nothing new.