### PR TITLE
fix: handle catId not existed. return 404 not found res

### DIFF
--- a/src/data-loaders/category-list-page.js
+++ b/src/data-loaders/category-list-page.js
@@ -2,6 +2,7 @@ import querystring from 'querystring'
 import get from 'lodash/get'
 import categoryConst from '../constants/category'
 import dataLoaderConst from '../constants/data-loaders'
+import statusCodeConst from '../constants/status-code'
 
 const _ = {
   get,
@@ -34,6 +35,19 @@ export default function loadData({ location, match, store }) {
 
   const pathSegment = _.get(match, 'params.category', '')
   const catId = categoryConst.ids[pathSegment]
+
+  if (!catId) {
+    // return status NotFound if catId not existed
+    const failAction = {
+      payload: {
+        error: {
+          statusCode: statusCodeConst.notFound,
+        },
+      },
+    }
+    return Promise.reject(failAction)
+  }
+
   return store.actions.fetchPostsByCategoryListId(
     catId,
     dataLoaderConst.categoryListPage.nPerPage,


### PR DESCRIPTION
### Reason to Change
In our [error reporting system](https://console.cloud.google.com/errors/COTC6tOXo6DYPQ?time=P30D&project=coastal-run-106202), there are lots of errors due to `catId` not existed.
However, that error should not be an error to be reported.
That error should be 404 (NotFound) error, not 500 (Internal server error) error.

