### PR TITLE
fix: handle author page 404 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@twreporter/index-page": "^1.1.0",
     "@twreporter/react-article-components": "^1.2.7",
     "@twreporter/react-components": "^8.3.4",
-    "@twreporter/redux": "^7.0.2",
+    "@twreporter/redux": "^7.0.3",
     "@twreporter/universal-header": "^2.1.6",
     "axios": "^0.19.0",
     "babel-polyfill": "^6.26.0",

--- a/src/data-loaders/author-page.js
+++ b/src/data-loaders/author-page.js
@@ -1,5 +1,6 @@
 // lodash
 import get from 'lodash/get'
+import statusCodeConst from '../constants/status-code'
 
 const _ = {
   get,
@@ -20,6 +21,19 @@ export default function loadData({ match, store }) {
   const authorId = _.get(match, 'params.authorId', '')
   return Promise.all([
     store.actions.fetchAuthorCollectionIfNeeded(authorId),
-    store.actions.fetchAuthorDetails(authorId),
+    store.actions.fetchAuthorDetails(authorId).then(successAction => {
+      const result = _.get(successAction, 'payload.normalizedData.result')
+      // no author details
+      if (!result) {
+        const failAction = {
+          payload: {
+            error: {
+              statusCode: statusCodeConst.notFound,
+            },
+          },
+        }
+        return Promise.reject(failAction)
+      }
+    }),
   ])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,10 +518,10 @@
     smoothscroll "^0.3.0"
     styled-components "^4.0.0"
 
-"@twreporter/redux@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@twreporter/redux/-/redux-7.0.2.tgz#0316e59b9e01eaecb1b9473d30e316ed37f276d5"
-  integrity sha512-H91sDWQg9xUzHajA+znI9z0sIiCWRqAUGuCNUnDscL+hpkXoTiZGhfS1URPmIdXwrKEf/6oudMJwfhUCMWBGoA==
+"@twreporter/redux@^7.0.2", "@twreporter/redux@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@twreporter/redux/-/redux-7.0.3.tgz#807f7519f8f0f02f99e3bcfbe99264b5f3b853b6"
+  integrity sha512-o4ptVZCfBakrcpa4mvRNQZCxdihW0/MURNGtWcOwRAoy9/vrEYMjNiTA3HkuxH12v2qL4dqjRJKnL1BDV9oPzA==
   dependencies:
     axios "^0.19.0"
     es6-error "^4.0.2"
@@ -534,24 +534,7 @@
     redux "^4.0.1"
     redux-thunk "^2.3.0"
 
-"@twreporter/universal-header@^2.1.6":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@twreporter/universal-header/-/universal-header-2.1.7.tgz#7b3c6a440a734cf00148d447b37e39efa807694a"
-  integrity sha512-iHTqmV9Xbqzsym/8Jtk8vV+6SEkO+3gZWVxFljz1jESynYKwBG+GEiuEv6TzaFUYQnTnnIo+zz2iftvaxE36Sw==
-  dependencies:
-    "@twreporter/core" "^1.2.0"
-    lodash "^4.17.11"
-    prop-types "^15.6.2"
-    querystring "^0.2.0"
-    react "^16.3.0"
-    react-redux "^6.0.0"
-    react-router-dom "^5.1.2"
-    react-transition-group "^2.0.0"
-    redux "^4.0.1"
-    redux-thunk "^2.3.0"
-    styled-components "^4.0.0"
-
-"@twreporter/universal-header@^2.1.8":
+"@twreporter/universal-header@^2.1.6", "@twreporter/universal-header@^2.1.8":
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/@twreporter/universal-header/-/universal-header-2.1.8.tgz#905a6334493f0b397f81428b77f63d900da4d02a"
   integrity sha512-FKENg2a4hqTUeQJZ1gH+51H9GEBRBDImrQ9+6m7Z9/Mqq9OpypVaXjyLAlXz3w7Kyjuido/tkCKEgufdrQvvyw==


### PR DESCRIPTION
### Reason to Change
In our error reporting system, we have been getting lots of server errors on author page (see [stackdriver error reporting](https://console.cloud.google.com/errors/CNHgkt_OkYeULg?time=P30D&project=coastal-run-106202)).

The root cause is that some end users requests url like `www.twreporter.org/authors/process064.html` (see [stackdriver logger](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%20resource.labels.cluster_name%3D%22twreporter%22%20resource.labels.namespace_name%3D%22production%22%20resource.labels.container_name%3D%22twreporter-nginx-v2%22%0AinsertId%3D%224nyzyf7ohhriubr1o%22;timeRange=2020-10-21T20:39:00.207Z%2F2020-10-21T20:40:00.207Z?project=coastal-run-106202)).
There is no data for such requests. 
Currently, our system responses 500 error page. 
However, we should response 404 error page instead.


### Solution
Due to [this PR](https://github.com/twreporter/twreporter-npm-packages/pull/155), 
our author page data loader could be updated to
- treat empty payload as 404 error