### PR TITLE
chore: update kustomize installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,17 +132,7 @@ jobs:
       - run:
           name: Install kustomize binaries
           command: |
-            opsys=linux
-            processor=amd64
-            curl -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases" |\
-            grep browser_download |\
-            grep $opsys |\
-            grep $processor |\
-            cut -d '"' -f 4 |\
-            grep /kustomize/v |\
-            sort | tail -n 1 |\
-            xargs curl -O -L
-            tar xzf ./kustomize_v*_${opsys}_${processor}.tar.gz -C /usr/bin
+            curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
             kustomize version
 
       - run:


### PR DESCRIPTION
This patch updates the kustomize installation steps according to
official
guide(https://kubectl.docs.kubernetes.io/installation/kustomize/binaries/).