### PR TITLE
chore: fix kustomize installation path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           name: Install kustomize binaries
           command: |
             curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
-            kustomize version
+            mv ./kustomize /usr/local/bin/
 
       - run:
           name: Prepare for kubernetes config build


### PR DESCRIPTION
This patch fixes the kustomize installation path which is default to
the current working directory. As the command is required to the
following steps, move it to /usr/local/bin/.