### PR TITLE
fix: utilize `window.location.href` as the path for GA

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -73,7 +73,7 @@ const store = twreporterRedux.createStore(
 
 // add Google Analytics
 ReactGA.initialize('UA-69336956-1')
-ReactGA.set({ page: window.location.pathname })
+ReactGA.set({ page: window.location.href })
 const jsx = (
   <BrowserRouter>
     <React.Fragment>


### PR DESCRIPTION
This patch utilizes `window.loaction.href` instead of
`window.location.pathname` as the path for Google Analytics to include
search strings.