### PR TITLE
fix: utilize `window.location.href` when sending pageview

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -60,7 +60,7 @@ function reloadPageIfNeeded() {
 function scrollToTopAndFirePageview() {
   window.scrollTo(0, 0)
   // send Google Analytics Pageview event on route changed
-  ReactGA.pageview(window.location.pathname)
+  ReactGA.pageview(window.location.href)
 
   return null
 }


### PR DESCRIPTION
This patch utilizes the `window.location.href` when sending GA pageview
event on client side.