### PR TITLE
fix(homepage): prevent sidebar from overlapping footer

### DIFF
--- a/src/components/side-bar/index-page-side-bar.js
+++ b/src/components/side-bar/index-page-side-bar.js
@@ -1,12 +1,10 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { Fragment } from 'react'
 import baseComponents from './base-components'
 import colors from '../../constants/colors'
 import mq from '../../utils/media-query'
 import styled from 'styled-components'
 
-// writing-mode: vertical-rl;
-// letter-spacing: 2px;
 const StyledAnchor = styled(baseComponents.StyledAnchor)`
   margin-bottom: 18px;
   color: ${props => (props.highlight ? 'white' : `${colors.primaryColor}`)};
@@ -22,11 +20,17 @@ class Anchors extends baseComponents.Anchors {
 
 const SideBarContainer = styled.div`
   position: fixed;
-  top: 50%;
+  @supports (position: sticky) {
+    position: sticky;
+  }
+
+  float: right;
+  right: 16px;
+  top: 50vh;
   z-index: 100;
   transform: translateY(-50%);
   color: ${colors.primaryColor};
-  right: 16px;
+  will-change: transform;
   ${mq.tabletOnly`
     right: 3px;
   `}
@@ -40,7 +44,7 @@ class HomePageSideBar extends React.PureComponent {
     // currentAnchorId and handleClickAnchor are passed from `SideBarHOC`
     const { anchors, children, currentAnchorId, handleClickAnchor } = this.props
     return (
-      <div>
+      <Fragment>
         <SideBarContainer>
           <Anchors
             data={anchors}
@@ -49,7 +53,7 @@ class HomePageSideBar extends React.PureComponent {
           />
         </SideBarContainer>
         {children}
-      </div>
+      </Fragment>
     )
   }
 }

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -85,7 +85,6 @@ const Container = styled.div`
   width: 100%;
   margin: 0 auto;
   background-color: white;
-  overflow: hidden;
   ${reactTransitionCSS}
 `
 


### PR DESCRIPTION
## Changes 

- Remove legacy commented styles.
- Replace unused div with React.Fragment.
- Adjust vertical center style in `index-page-side-bar`.
- Remove `overflow: hidden` from `container`.

## Description

According to best practice `graceful degradation`, using position `sticky`(for modern browser) + `fixed`(for legacy browser) to fix this styling issue.

## Screenshot
![image](https://user-images.githubusercontent.com/40432044/119451053-6218b680-bd67-11eb-8f27-bb67a00dd7cf.png)
![image](https://user-images.githubusercontent.com/40432044/119451028-588f4e80-bd67-11eb-99c5-84db8ff8f6fe.png)

## Related Issue 
Resolves: #1846