### PR TITLE
chore: downgrade version to v4.6.10-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.6.10 (Current), 2021-05-26
+## 4.6.10-rc.1 (Current), 2021-05-26
 
 ### Notable Changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "4.6.10",
+  "version": "4.6.10-rc.1",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",


### PR DESCRIPTION
This patch downgrades version from v4.6.10 to v4.6.10-rc.1 due to
index page incorrect UI behavior on mobile.