### PR TITLE
fix: fix slideshow effect for mobile devices on index page

### DIFF
--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import categoryConst from '../constants/category'
 import loggerFactory from '../logger'
+import mq from '../utils/media-query'
 import qs from 'qs'
 import sideBarFactory from '../components/side-bar/side-bar-factory'
 import siteMeta from '../constants/site-meta'
@@ -85,6 +86,9 @@ const Container = styled.div`
   width: 100%;
   margin: 0 auto;
   background-color: white;
+  ${mq.mobileOnly`
+    overflow: hidden;
+  `}
   ${reactTransitionCSS}
 `
 


### PR DESCRIPTION
## Changes
- add `overflow: hidden` to index page container to fix slideshow effect

## Description
On [staging.twreporter.org](https://staging.twreporter.org), slideshow effect does not work as expected on mobile devices.
The misbehavior can only be reproduced on real mobile devices, not the browser emulator.

### screenshot
![IMG_6E1F7044F241-1](https://user-images.githubusercontent.com/6375655/119924394-0f790d80-bfa6-11eb-8e47-802218e21d93.jpeg)
