### PR TITLE
chore(release): bump version to v4.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.6.10-rc.2 (Current), 2021-05-28
+## 4.6.10 (Current), 2021-05-28
 
 ### Notable Changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "4.6.10-rc.2",
+  "version": "4.6.10",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",


### PR DESCRIPTION
This patch bumps version to v4.6.10 since it hasn't been released yet.