### PR TITLE
refactor: remove the default email of authors

### DIFF
--- a/src/containers/Author.js
+++ b/src/containers/Author.js
@@ -29,8 +29,6 @@ const authorDefaultImg = {
   height: 500,
 }
 
-const defaultEmail = 'contact@twreporter.org'
-
 const logger = loggerFactory.getLogger()
 
 class Author extends React.Component {
@@ -166,7 +164,7 @@ function mapStateToProps(state, ownProps) {
     name: _.get(authorEntity, 'name') || '',
     title: _.get(authorEntity, 'jobTitle') || '',
     image: authorImage,
-    mail: _.get(authorEntity, 'email') || defaultEmail,
+    mail: _.get(authorEntity, 'email') || '',
     bio: _.get(authorEntity, 'bio' || ''),
   }
   return {


### PR DESCRIPTION
This patch removes the default email(contact@twreporter.org) of authors.
Address the inquiry from the editors.

issue: twreporter-36