### PR TITLE
feat: manually send gtm.load event for SPA

### DIFF
--- a/src/components/about-us/index.js
+++ b/src/components/about-us/index.js
@@ -17,6 +17,7 @@ import styled from 'styled-components'
 import WebFont from './web-font'
 import { AnchorWrapper as Anchor } from '@twreporter/react-components/lib/side-bar'
 import { Opening } from './opening'
+import TagManager from 'react-gtm-module'
 
 const Border = styled.div`
   ${mq.hdOnly`
@@ -47,6 +48,12 @@ export class AboutUs extends PureComponent {
     return smoothScroll(this.sectionOffset[anchorIdx])
   }
   componentDidMount() {
+    // For client-side rendering, we notify GTM that the new component is ready
+    TagManager.dataLayer({
+      dataLayer: {
+        event: 'gtm.load',
+      },
+    })
     this.sectionOffset = this.sectionRefs.map(elem => {
       return ReactDOM.findDOMNode(elem).getBoundingClientRect().top
     })

--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -1,6 +1,7 @@
 import ArticleComponent from '@twreporter/react-article-components'
 import ArticlePlaceholder from '../components/article/placeholder'
 import Helmet from 'react-helmet'
+import TagManager from 'react-gtm-module'
 import loggerFactory from '../logger'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
@@ -56,6 +57,12 @@ class Article extends PureComponent {
   }
 
   componentDidMount() {
+    // For client-side rendering, we notify GTM that the new component is ready
+    TagManager.dataLayer({
+      dataLayer: {
+        event: 'gtm.load',
+      },
+    })
     // detect scroll position
     window.addEventListener('scroll', this.handleScroll)
     const { fontLevel, changeFontLevel, slugToFetch } = this.props

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -22,6 +22,7 @@ import cloneUtils from '../utils/shallow-clone-entity'
 import get from 'lodash/get'
 import map from 'lodash/map'
 import merge from 'lodash/merge'
+import TagManager from 'react-gtm-module'
 
 const {
   CategorySection,
@@ -184,6 +185,12 @@ class Homepage extends React.PureComponent {
   }
 
   componentDidMount() {
+    // For client-side rendering, we notify GTM that the new component is ready
+    TagManager.dataLayer({
+      dataLayer: {
+        event: 'gtm.load',
+      },
+    })
     this.fetchIndexPageContentWithCatch()
     this.fetchFeatureTopicWithCatch().then(() => {
       // EX: if the url path is /?section=categories


### PR DESCRIPTION
This patch sends the `gtm.load` event to reset gtm scroll depth as sonn
as the window is ready.