### PR TITLE
fix: send gtm.load event when the content is ready

### DIFF
--- a/src/containers/Article.js
+++ b/src/containers/Article.js
@@ -57,12 +57,6 @@ class Article extends PureComponent {
   }
 
   componentDidMount() {
-    // For client-side rendering, we notify GTM that the new component is ready
-    TagManager.dataLayer({
-      dataLayer: {
-        event: 'gtm.load',
-      },
-    })
     // detect scroll position
     window.addEventListener('scroll', this.handleScroll)
     const { fontLevel, changeFontLevel, slugToFetch } = this.props
@@ -90,6 +84,14 @@ class Article extends PureComponent {
   componentDidUpdate(prevProps) {
     if (prevProps.slugToFetch !== this.props.slugToFetch) {
       this.fetchAFullPostWithCatch(this.props.slugToFetch)
+    }
+    if (prevProps.isFetchingPost && !this.props.isFetchingPost) {
+      // For client-side rendering, we notify GTM that the new component is ready when the fetching is done.
+      TagManager.dataLayer({
+        dataLayer: {
+          event: 'gtm.load',
+        },
+      })
     }
   }
 

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -176,6 +176,7 @@ class Homepage extends React.PureComponent {
     fetchIndexPageContent: PropTypes.func,
     fetchFeatureTopic: PropTypes.func,
     isSpinnerDisplayed: PropTypes.bool,
+    isContentReady: PropTypes.bool,
     categories: PropTypes.array,
   }
 
@@ -185,12 +186,6 @@ class Homepage extends React.PureComponent {
   }
 
   componentDidMount() {
-    // For client-side rendering, we notify GTM that the new component is ready
-    TagManager.dataLayer({
-      dataLayer: {
-        event: 'gtm.load',
-      },
-    })
     this.fetchIndexPageContentWithCatch()
     this.fetchFeatureTopicWithCatch().then(() => {
       // EX: if the url path is /?section=categories
@@ -203,6 +198,17 @@ class Homepage extends React.PureComponent {
         this._sidebar.current.handleClickAnchor(section)
       }
     })
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.isContentReady && this.props.isContentReady) {
+      // For client-side rendering, we notify GTM that the new component is ready
+      TagManager.dataLayer({
+        dataLayer: {
+          event: 'gtm.load',
+        },
+      })
+    }
   }
 
   fetchIndexPageContentWithCatch = () => {
@@ -563,6 +569,7 @@ function mapStateToProps(state) {
     {
       isSpinnerDisplayed: !_.get(indexPageState, 'isReady', false),
       ifAuthenticated: _.get(state, ['auth', 'authenticated'], false),
+      isContentReady: _.get(indexPageState, 'isReady', false),
     }
   )
 }


### PR DESCRIPTION
This patch sends the gtm.load event when the content is ready.