### PR TITLE
refactor: remove utm parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "dependencies": {
     "@google-cloud/logging-winston": "^3.0.2",
     "@twreporter/core": "^1.2.1",
-    "@twreporter/index-page": "1.2.4",
-    "@twreporter/react-article-components": "1.3.2-rc.0",
-    "@twreporter/react-components": "8.4.3",
+    "@twreporter/index-page": "1.2.5-rc.0",
+    "@twreporter/react-article-components": "1.3.2-rc.1",
+    "@twreporter/react-components": "8.4.4-rc.0",
     "@twreporter/redux": "7.2.0",
     "@twreporter/universal-header": "^2.1.6",
     "axios": "^0.19.0",

--- a/src/components/Sponsor.js
+++ b/src/components/Sponsor.js
@@ -1,5 +1,5 @@
 import { sourceHanSansTC as fontWeight } from '@twreporter/core/lib/constants/font-weight'
-import DonationLink from '@twreporter/react-components/lib/donation-link-with-utm'
+import DonationLink from '@twreporter/react-components/lib/donation-link'
 import mq from '../utils/media-query'
 import React from 'react'
 import Sizing from './sizing'
@@ -77,7 +77,7 @@ class Sponsor extends React.Component {
           </p>
           <p>竭誠歡迎認同《報導者》理念的朋友贊助支持我們！</p>
         </Desc>
-        <SponsorButton utmMedium="author">贊助我們</SponsorButton>
+        <SponsorButton>贊助我們</SponsorButton>
       </Container>
     )
   }

--- a/src/components/about-us/opening/anchors-panel.js
+++ b/src/components/about-us/opening/anchors-panel.js
@@ -7,7 +7,7 @@ import { replaceGCSUrlOrigin } from '@twreporter/core/lib/utils/storage-url-proc
 import mq from '../../../utils/media-query'
 import { storageUrlPrefix } from '../utils/config'
 import anchorlist from '../constants/data/sidebar-anchor'
-import DonationLink from '@twreporter/react-components/lib/donation-link-with-utm'
+import DonationLink from '@twreporter/react-components/lib/donation-link'
 import hrefs from '../constants/data/sidebar-link'
 import { Link } from 'react-router-dom'
 import logo from '../../../../static/asset/about-us/Thereporter-logo-mono-white.png'
@@ -245,7 +245,7 @@ class AnchorsPanel extends React.PureComponent {
           <ContentWrapper>
             <AnchorsContainer>{Anchors}</AnchorsContainer>
             <Icons>
-              <DonationLink utmMedium="about-us">
+              <DonationLink>
                 <img
                   src={`${replaceGCSUrlOrigin(
                     `${storageUrlPrefix}/sidebar-icon1-white.png`

--- a/src/components/side-bar/aboutus-page-side-bar.js
+++ b/src/components/side-bar/aboutus-page-side-bar.js
@@ -1,7 +1,7 @@
 import { buildFbShareLink } from '../about-us/utils/build-fb-share-link'
 import { replaceGCSUrlOrigin } from '@twreporter/core/lib/utils/storage-url-processor'
 import { storageUrlPrefix } from '../about-us/utils/config'
-import DonationLink from '@twreporter/react-components/lib/donation-link-with-utm'
+import DonationLink from '@twreporter/react-components/lib/donation-link'
 import PropTypes from 'prop-types'
 import React from 'react'
 import anchorlist from '../about-us/constants/data/sidebar-anchor'
@@ -131,7 +131,7 @@ class AboutusPageSideBar extends React.PureComponent {
             currentAnchorId={currentAnchorId}
           />
           <Icons>
-            <DonationLink utmMedium="about-us">
+            <DonationLink>
               <img
                 src={`${replaceGCSUrlOrigin(
                   `${storageUrlPrefix}/sidebar-icon1.png`

--- a/src/components/topic/header.js
+++ b/src/components/topic/header.js
@@ -7,7 +7,7 @@ import WhiteDonationIcon from '../../../static/asset/white-donation-icon.svg'
 import WhiteLogoIcon from '../../../static/asset/logo-white-s.svg'
 // @twreporter
 import { sourceHanSansTC as fontWeight } from '@twreporter/core/lib/constants/font-weight'
-import DonationLink from '@twreporter/react-components/lib/donation-link-with-utm'
+import DonationLink from '@twreporter/react-components/lib/donation-link'
 
 const Container = styled.div`
   position: absolute;
@@ -60,7 +60,7 @@ const LogoLink = styled(Link)`
 function Header() {
   return (
     <Container>
-      <DonationLink utmMedium="topic">
+      <DonationLink>
         <DonationBtn>
           <WhiteDonationIcon />
           <span>贊助我們</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,13 +464,13 @@
     prop-types "^15.0.0"
     styled-components "^4.0.0"
 
-"@twreporter/index-page@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@twreporter/index-page/-/index-page-1.2.4.tgz#e1bcb5583fc64ac2339cad9afbcf89fe6320b860"
-  integrity sha512-zwY8tiDlwm0p4sz0rFpq7CtiuEn/Zp5tITmDPvvYQa6GGSbrBlwsby5tvrkUVojFLj9FgaaZIK8RVHO7VLYC6A==
+"@twreporter/index-page@1.2.5-rc.0":
+  version "1.2.5-rc.0"
+  resolved "https://registry.yarnpkg.com/@twreporter/index-page/-/index-page-1.2.5-rc.0.tgz#0b816866d754ec7ae9df40c2235d6915cb0e63a3"
+  integrity sha512-LLphuAhyxTcIZXfW//x5c84d/xZupHbGSp1Y8RX7XROZCK8GQsX+YjmLbfCwTYYis4GrU70HL5CS9+HRqzUsIA==
   dependencies:
     "@twreporter/core" "^1.2.1"
-    "@twreporter/react-components" "^8.4.3"
+    "@twreporter/react-components" "^8.4.4-rc.0"
     lodash "^4.0.0"
     prop-types "^15.0.0"
     react "^16.3.0"
@@ -482,13 +482,13 @@
     styled-components "^4.0.0"
     velocity-react "^1.4.3"
 
-"@twreporter/react-article-components@1.3.2-rc.0":
-  version "1.3.2-rc.0"
-  resolved "https://registry.yarnpkg.com/@twreporter/react-article-components/-/react-article-components-1.3.2-rc.0.tgz#79d078c9859c0a0adb2f91f977fd77b1edac0c60"
-  integrity sha512-LllN3Oof73Xo6wO18pCYpACZC6+G/vp2qqkZsi+91jqQ2Tdu3TcvuO5wohEEKWeXOsKeEEcTAP3SHU6tfqwYOQ==
+"@twreporter/react-article-components@1.3.2-rc.1":
+  version "1.3.2-rc.1"
+  resolved "https://registry.yarnpkg.com/@twreporter/react-article-components/-/react-article-components-1.3.2-rc.1.tgz#c75b24a381ebbf70c53b64a08e01bad225da04b6"
+  integrity sha512-GWyczqt9WmxW5GLsL5PERUr97Kz2VqJroG3xTjDDJ/5gi0r0QHEMghYMSb0ip0jruOlPRcEnP0SLulyJCh89sw==
   dependencies:
     "@twreporter/core" "^1.2.1"
-    "@twreporter/react-components" "^8.4.3"
+    "@twreporter/react-components" "^8.4.4-rc.0"
     "@twreporter/redux" "^7.2.0"
     "@twreporter/universal-header" "^2.1.8"
     howler "^2.1.1"
@@ -500,10 +500,10 @@
     smoothscroll "^0.3.0"
     styled-components "^4.0.0"
 
-"@twreporter/react-components@8.4.3", "@twreporter/react-components@^8.4.3":
-  version "8.4.3"
-  resolved "https://registry.yarnpkg.com/@twreporter/react-components/-/react-components-8.4.3.tgz#20008568bd522f6547797de5a33a32d2ca955442"
-  integrity sha512-pAVEjeUyvq9AbKyCM85O+NRAazyUIf/Zm10kToNbvN53SiPmbYTlL9uGQjsZXerDQMWN3pxF0nCpqO+TkXRsnw==
+"@twreporter/react-components@8.4.4-rc.0", "@twreporter/react-components@^8.4.4-rc.0":
+  version "8.4.4-rc.0"
+  resolved "https://registry.yarnpkg.com/@twreporter/react-components/-/react-components-8.4.4-rc.0.tgz#ae8b2dcc9247513afa65deaf2e6e1d6dce1d2828"
+  integrity sha512-P0aKqf4SBWgTAQdyb3HDhXnAd7JPBDtbdf7yT267EiD/Y9KRgaMzUTDYz1lWeld/JVA7vQoDrDDSbA9ka7SDGQ==
   dependencies:
     "@twreporter/core" "^1.2.1"
     "@twreporter/redux" "^7.2.0"


### PR DESCRIPTION
Address [twreporter-66 Remove outbound links with utm
tracking](https://twreporter-org.atlassian.net/browse/TWREPORTER-66).

Since we are migrating to GTM, we will remove the legacy utm search
parameters to avoid duplicated trigger for the same metrics.