### PR TITLE
fix(search-box): give input a specific width to avoid bug in firefox

### DIFF
--- a/src/components/topic/search-box.js
+++ b/src/components/topic/search-box.js
@@ -46,6 +46,7 @@ const Input = styled.input`
   outline: none;
   border: none;
   height: 100%;
+  width: 200px;
   margin: 0;
   padding-left: 10px;
   background-color: transparent;


### PR DESCRIPTION
## Changes

- Add width for input in the search box

## Description

Input's width won't be limited by the parent's width In Firefox. So make the input 200px can fix the bug in Firefox.

## Related Issue

Resolves: #1871