### PR TITLE
refactor: update font-family for English text on topic landing page

### DIFF
--- a/src/components/topic/banner/base.js
+++ b/src/components/topic/banner/base.js
@@ -1,6 +1,7 @@
-import styled from 'styled-components'
-import { sourceHanSansTC as fontWeight } from '@twreporter/core/lib/constants/font-weight'
 import mq from '../../../utils/media-query'
+import styled from 'styled-components'
+import typography from '../../../constants/typography'
+import { sourceHanSansTC as fontWeight } from '@twreporter/core/lib/constants/font-weight'
 
 const textShadow = '0 2px 10px rgba(0, 0, 0, .5)'
 
@@ -15,6 +16,7 @@ const Content = styled.div`
 `
 
 const Headline = styled.div`
+  font-family: ${typography.font.fontFamily.default};
   color: #ffffff;
   display: inline-block;
   background-color: #c71b0a;
@@ -25,6 +27,7 @@ const Headline = styled.div`
 `
 
 const Title = styled.h1`
+  font-family: ${typography.font.fontFamily.default};
   color: #ffffff;
   margin: 0;
   font-size: 30px;
@@ -38,6 +41,7 @@ const Title = styled.h1`
 `
 
 const Subtitle = styled.h2`
+  font-family: ${typography.font.fontFamily.default};
   color: #ffffff;
   margin: 0;
   font-size: 18px;
@@ -72,6 +76,7 @@ const ArrowDown = styled.div`
 `
 
 const PublishDate = styled.div`
+  font-family: ${typography.font.fontFamily.default};
   color: #ffffff;
   font-size: 13px;
   font-weight: ${fontWeight.normal};

--- a/src/components/topic/related/base.js
+++ b/src/components/topic/related/base.js
@@ -1,9 +1,10 @@
-import { sourceHanSansTC as fontWeight } from '@twreporter/core/lib/constants/font-weight'
-import { Link } from 'react-router-dom'
-import mq from '../../../utils/media-query'
 import PropTypes from 'prop-types'
 import React from 'react'
+import mq from '../../../utils/media-query'
 import styled, { keyframes } from 'styled-components'
+import typography from '../../../constants/typography'
+import { Link } from 'react-router-dom'
+import { sourceHanSansTC as fontWeight } from '@twreporter/core/lib/constants/font-weight'
 
 const fadeInSlideDown = keyframes`
   from {
@@ -51,8 +52,8 @@ const ItemMeta = styled.div`
     width: calc(100% - 110px);
   `}
 `
-
 const ItemTitle = styled.h3`
+  font-family: ${typography.font.fontFamily.default};
   font-size: 20px;
   color: #262626;
   letter-spacing: 0.3px;
@@ -63,6 +64,7 @@ const ItemTitle = styled.h3`
 `
 
 const ItemDescription = styled.div`
+  font-family: ${typography.font.fontFamily.default};
   ${mq.mobileOnly`
     display: none;
   `}
@@ -75,6 +77,7 @@ const ItemDescription = styled.div`
 `
 
 const ItemDate = styled.div`
+  font-family: ${typography.font.fontFamily.default};
   ${mq.mobileOnly`
     display: none;
   `}

--- a/src/constants/typography.js
+++ b/src/constants/typography.js
@@ -15,5 +15,9 @@ export default {
       normal: '300',
       bold: '700',
     },
+    fontFamily: {
+      // ff-tisa-web-pro is for english text
+      default: 'ff-tisa-web-pro, source-han-sans-traditional, sans-serif',
+    },
   },
 }


### PR DESCRIPTION
Resolve [TWREPORTER-109](https://twreporter-org.atlassian.net/browse/TWREPORTER-109)

Currently, English text can not display properly on topic landing page
due to the font family issue.
Since this change, font-family is updated to `ff-tisa-web-pro` by default,
which is identical with the font-family setting in article pages.