### PR TITLE
fix: call to action banner can not be clicked

### DIFF
--- a/src/components/web-push.js
+++ b/src/components/web-push.js
@@ -69,8 +69,12 @@ function isServiceWorkerSupported() {
 const NotifyBackground = styled.div`
   background-color: #fff;
 
-  /* z-index and position are set for covering header */
-  z-index: 1;
+  /* z-index and position are set for covering header.
+   * Set z-index to 1000 because header has z-index 999,
+   * and notify background should be on top of header or
+   * buttons can not be clicked.
+   * /
+  z-index: 1000;
   position: relative;
 `
 

--- a/src/containers/app-shell.js
+++ b/src/containers/app-shell.js
@@ -35,7 +35,6 @@ const TransparentHeader = styled.div`
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 1;
   ${mq.mobileOnly`
     position: relative;
   `}


### PR DESCRIPTION
Address [TWREPORTER-140](https://twreporter-org.atlassian.net/browse/TWREPORTER-140?atlOrigin=eyJpIjoiNDczOGVjOTgxMGEyNDQwZTk4NTMyMTQ4ZTg4NzY0NDMiLCJwIjoiaiJ9)

This change updates z-index for web push component to ensure it can be
clicked when header is in theme transparent.

screenshot:
![image](https://user-images.githubusercontent.com/6375655/134865218-876637a2-3f78-45e8-be97-563d66988e68.png)
