### PR TITLE
feat: add animation to indicator of carousel & enhance contrast

### DIFF
--- a/src/components/photography/slider.js
+++ b/src/components/photography/slider.js
@@ -11,7 +11,7 @@ const _ = {
   map,
 }
 
-const DEFAULT_INDICATOR_COLOR = 'rgb(113, 113, 113)'
+const defaultIndicatorColor = 'rgb(113, 113, 113)'
 
 const SlidesContainer = styled.div`
   position: relative;
@@ -70,8 +70,7 @@ const Indicator = styled.li`
   min-height: 10px;
   width: 0.6em;
   height: 0.6em;
-  background-color: ${props =>
-    props.focus ? 'white' : DEFAULT_INDICATOR_COLOR};
+  background-color: ${props => (props.focus ? 'white' : defaultIndicatorColor)};
   transition: background-color 0.6s ease;
   margin: 0 0.8em;
   border-radius: 50%;

--- a/src/components/photography/slider.js
+++ b/src/components/photography/slider.js
@@ -11,6 +11,8 @@ const _ = {
   map,
 }
 
+const DEFAULT_INDICATOR_COLOR = 'rgb(113, 113, 113)'
+
 const SlidesContainer = styled.div`
   position: relative;
   overflow: visible;
@@ -68,7 +70,9 @@ const Indicator = styled.li`
   min-height: 10px;
   width: 0.6em;
   height: 0.6em;
-  background-color: ${props => (props.focus ? 'white' : '#BEC0BC')};
+  background-color: ${props =>
+    props.focus ? 'white' : DEFAULT_INDICATOR_COLOR};
+  transition: background-color 0.6s ease;
   margin: 0 0.8em;
   border-radius: 50%;
   overflow: hidden;


### PR DESCRIPTION
hi, this is 守傑 & it's a minor improvement of the indicator of carousel:

1. add fading animation of indicators.
2. enhance indicator's contrast between active/inactive states.

please give comments or suggestions, thanks!