### PR TITLE
fix: fix eslint error

### DIFF
--- a/src/components/about-us/section-05/timeline.js
+++ b/src/components/about-us/section-05/timeline.js
@@ -182,6 +182,10 @@ Timeline.defaultProps = {
 }
 
 Timeline.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
   autoScrolling: PropTypes.bool,
   childrenHeight: PropTypes.number,
   getYear: PropTypes.func.isRequired,

--- a/src/components/about-us/utils/error-boundary.js
+++ b/src/components/about-us/utils/error-boundary.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import { colorSupportive } from '@twreporter/core/lib/constants/color'
@@ -9,7 +10,10 @@ const ErrorContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  a, a:link, a:active, a:visited {
+  a,
+  a:link,
+  a:active,
+  a:visited {
     color: ${colorSupportive.heavy};
   }
   a:hover {
@@ -24,13 +28,14 @@ class ErrorBoundary extends React.Component {
   }
 
   static getDerivedStateFromError(error) {
-    return { isError: true }
+    if (error) {
+      return { isError: true }
+    }
   }
 
   componentDidCatch(error, errorInfo) {
     console.error(error, errorInfo)
   }
-
 
   render() {
     if (this.state.isError) {
@@ -52,4 +57,11 @@ class ErrorBoundary extends React.Component {
   }
 }
 
-export default ErrorBoundary 
+ErrorBoundary.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+}
+
+export default ErrorBoundary

--- a/src/containers/app-shell.js
+++ b/src/containers/app-shell.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux'
 import ErrorBoundary from '../components/ErrorBoundary'
 import Footer from '@twreporter/react-components/lib/footer'
 import Header from '@twreporter/universal-header/lib/containers/header'
-import mq from '@twreporter/core/lib/utils/media-query'
 import PropTypes from 'prop-types'
 import React from 'react'
 import WebPush from '../components/web-push'
@@ -50,7 +49,9 @@ const renderFooter = (footerType, pathname = '', host = '', releaseBranch) => {
     }
     case uiConst.footer.default:
     default: {
-      return <Footer host={host} pathname={pathname} releaseBranch={releaseBranch} />
+      return (
+        <Footer host={host} pathname={pathname} releaseBranch={releaseBranch} />
+      )
     }
   }
 }


### PR DESCRIPTION
This patch fixes lint error as follows:
- 'children' is missing in props validation
- Expected error to be handled
- 'mq' is defined but never used