### PR TITLE
feat: add releaseBranch props into route component

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -131,16 +131,9 @@ export default class App extends React.Component {
                 <Switch>
                   {routes.map((route, routeIndex) => {
                     if (route.renderWithProps) {
-                      const render = props => (
+                      route.render = props => (
                         <route.renderWithProps
                           releaseBranch={releaseBranch}
-                          {...props}
-                        />
-                      )
-                      return (
-                        <Route
-                          key={`route-${routeIndex}`}
-                          render={render}
                           {...props}
                         />
                       )

--- a/src/app.js
+++ b/src/app.js
@@ -129,9 +129,24 @@ export default class App extends React.Component {
             return (
               <AppShell location={props.location} releaseBranch={releaseBranch}>
                 <Switch>
-                  {routes.map((route, routeIndex) => (
-                    <Route key={`route-${routeIndex}`} {...route} />
-                  ))}
+                  {routes.map((route, routeIndex) => {
+                    if (route.renderWithProps) {
+                      const render = props => (
+                        <route.renderWithProps
+                          releaseBranch={releaseBranch}
+                          {...props}
+                        />
+                      )
+                      return (
+                        <Route
+                          key={`route-${routeIndex}`}
+                          render={render}
+                          {...props}
+                        />
+                      )
+                    }
+                    return <Route key={`route-${routeIndex}`} {...route} />
+                  })}
                 </Switch>
               </AppShell>
             )

--- a/src/routes.js
+++ b/src/routes.js
@@ -247,7 +247,7 @@ export default function getRoutes() {
       path: routesConst.aboutUsPage.path,
     },
     {
-      component: loadablePages.bookmarkList,
+      renderWithProps: loadablePages.bookmarkList,
       loadData: dataLoaders.loadBookmarkListData,
       path: routesConst.bookmarkListPage.path,
       authorizationRequired: true,


### PR DESCRIPTION
This patch add custom `renderWithProps` key to identify whether component in react router need to inject `releaseBranch` props or not.
ref: [react route doc](https://v5.reactrouter.com/web/api/Route)