### PR TITLE
fix: change web font loader to address typekit embedded code issue

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -94,17 +94,20 @@ export default class Html extends PureComponent {
           {_.map(scripts, (script, key) => (
             <script src={script} key={'scripts' + key} charSet="UTF-8" />
           ))}
-
           {/* <!-- Load typekit fonts for twreporter.org domain--> */}
           <script
             dangerouslySetInnerHTML={{
-              __html: `(function(d) {
-                var config = {
-                kitId: 'vlk1qbe',
-                scriptTimeout: 3000,
-                async: true
-              },h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
-            })(document);`,
+              __html: `
+                WebFontConfig = {
+                  typekit: { id: 'vlk1qbe' }
+                };
+                (function(d) {
+                   var wf = d.createElement('script'), s = d.scripts[0];
+                   wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
+                   wf.async = true;
+                   s.parentNode.insertBefore(wf, s);
+                })(document);
+              `,
             }}
           />
           {/* <!-- End - Load typekit fonts for twreporter.org domain--> */}


### PR DESCRIPTION
Address [TWREPORTER-318](https://twreporter-org.atlassian.net/browse/TWREPORTER-318)

This patch adopts
[webfontloader](https://github.com/typekit/webfontloader) to load
typekit web font to address an issue in Safari, especially mobile
Safari, where white spaces keep occupying screen when user touch
moving.

