### PR TITLE
refactor: use inline style changing widith of reading progress

### DIFF
--- a/src/components/article/reading-progress.js
+++ b/src/components/article/reading-progress.js
@@ -2,16 +2,17 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 
-const Bar = styled.div`
+const Bar = styled.div.attrs(({ percent }) => ({
+  style: {
+    width: percent + '%',
+  },
+}))`
   position: fixed;
   top: 0;
   left: 0;
   z-index: 999;
   background-color: rgba(198, 0, 11, 0.35);
   height: 2px;
-  width: ${props => {
-    return props.percent + '%'
-  }};
   transition: 0.2s width linear;
 `
 


### PR DESCRIPTION
Address [TWREPORTER-318](https://twreporter-org.atlassian.net/browse/TWREPORTER-318)

This patch uses the `attrs` method, together with a style object
changes the in-line style for frequently changing width of reading
progresss instead of generating unique classes whenever its style
changes since generating CSS classes isn't a lightweight operation.

Please note that this change aims to mitigate the 'blank page' issue in
iOS Safari/Chrome/Firefox where renders white spaces on part of screen.