### PR TITLE
Jason/stats js

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "rimraf": "^2.5.2",
     "webpack": "^3.8.1",
     "webpack-bundle-analyzer": "^3.3.2",
-    "webpack-dev-server": "^2.9.5"
+    "webpack-dev-server": "^2.9.5",
+    "stats-js": "^1.0.1"
   },
   "husky": {
     "hooks": {

--- a/src/client.js
+++ b/src/client.js
@@ -135,6 +135,25 @@ const jsx = (
 Loadable.preloadReady().then(() => {
   if (globalEnv.isDevelopment) {
     ReactDOM.render(jsx, document.getElementById('root'))
+
+    // FPS meter
+    import('stats-js')
+      .then(Stats => {
+        const stats = new Stats()
+        stats.showPanel(0) // 0: fps, 1: ms, 2: mb, 3+: custom
+        document.body.appendChild(stats.dom)
+        function animate() {
+          stats.begin()
+          stats.end()
+          window.requestAnimationFrame(animate)
+        }
+        window.requestAnimationFrame(animate)
+        stats.dom.style.right = '0'
+        stats.dom.style.left = 'initial'
+      })
+      .catch(err => {
+        console.log(err)
+      })
     return
   }
   ReactDOM.hydrate(jsx, document.getElementById('root'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -7977,6 +7977,11 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+stats-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stats-js/-/stats-js-1.0.1.tgz#377c36490c1935b9a4e68bf3acc3afeb59878f66"
+  integrity sha512-EAwEFghGNv8mlYC4CZzI5kWghsnP8uBKXw6VLRHtXkOk5xySfUKLTqTkjgJFfDluIkf/O7eZwi5MXP50VeTbUg==
+
 "statuses@>= 1.4.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"


### PR DESCRIPTION
integrate stats-js for performance monitoring during development, can trace FPS/memory usage on demand

<img width="401" alt="Screen Shot 2022-06-06 at 11 33 29 AM" src="https://user-images.githubusercontent.com/25971696/172090216-c3d6be44-f5be-4dfc-af71-97f1ad55334e.png">
<img width="406" alt="Screen Shot 2022-06-06 at 11 33 38 AM" src="https://user-images.githubusercontent.com/25971696/172090238-d451944f-a493-4d3c-96f6-07f1b8f765b7.png">


