### PR TITLE
docs: update award name in about-us

### DIFF
--- a/src/components/about-us/constants/section-03/awards-name.json
+++ b/src/components/about-us/constants/section-03/awards-name.json
@@ -1,8 +1,8 @@
 [
   {
     "awardId": "sopa",
-    "award": "SOPA亞洲出版協會",
-    "awardEng": "The Society of Publishers in Asia"
+    "award": "SOPA亞洲出版協會新聞獎",
+    "awardEng": "The Society of Publishers in Asia Awards"
   },
   {
     "awardId": "taiHai",


### PR DESCRIPTION
Address [TWREPORTER-391](https://twreporter-org.atlassian.net/browse/TWREPORTER-391)

Since the award name (SOPA亞洲出版協會) changes in [spreadsheet](https://docs.google.com/spreadsheets/d/16CVkhaSw5sxwjlSt1c0nLzxG7qzEmeO2gCymVsSY6PE/edit?pli=1#gid=1007344551), the award name should be changed too.