### PR TITLE
refactor: adopt adobe font as the third-party web fonts

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -110,39 +110,19 @@ export default class Html extends PureComponent {
           {_.map(scripts, (script, key) => (
             <script src={script} key={'scripts' + key} charSet="UTF-8" />
           ))}
-          {/* <!-- Load google fonts --> */}
           <script
             dangerouslySetInnerHTML={{
-              __html: `
-              (function(document) {
-                var gf = document.createElement("link"),
-                gfApi = document.createElement("link");
-                gf.rel="dns-prefetch";
-                gf.href="https://fonts.googleapis.com";
-                gfApi.rel="preconnect";
-                gfApi.href="https://fonts.gstatic.com";
-                gfApi.crossOrigin="anonymous";
-                document.head.appendChild(gf);
-                document.head.appendChild(gfApi);
-                var wf = document.createElement("script"),
-                webFontConfig={
-                  google: {
-                    families: ['Merriweather:700','Rosario:400,700','Noto+Serif+TC:500,600,700&display=swap']
-                  }
-                };
-                wf.type = "text/javascript";
-                wf.src = "https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js";
-                wf.async = true;
-                wf.onload=wf.onreadystatechange=function () {
-                  try{
-                    WebFont.load(webFontConfig);
-                  }catch(e){};
-                };
-                document.head.appendChild(wf);
-              })(document)`,
+              __html: `(function(d) {
+                var config = {
+                  kitId: 'vlk1qbe',
+                  scriptTimeout: 3000,
+                  async: true
+                },
+                h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
+              })(document);
+            `,
             }}
           />
-          {/* <!-- End - Load google fonts--> */}
         </body>
       </html>
     )


### PR DESCRIPTION
Address [Reduce unused CSS: google font CSS link](https://app.asana.com/0/0/1202942985879129/f)

Note that https://github.com/twreporter/twreporter-npm-packages/pull/314 is needed by this change.


This patch regresses to adopt adobe font as the third-party web fonts, here is the reasons:

- In previous change, we used google font to replace adobe font to address the render blocking issue which leads to white page appears while scrolling in iOS browsers.
- After a while, we found that the cause of that issue was the subsetting of a specific font 'Noto Sans TC' and we decided to self-host that font on gcs as a whole (without subsetting).
- So we can see adobe font service has nothing to do with this issue.
- This change aims to improve the performance of the website suggested by PageSpeed Insight, which were:
  - Reduce unused CSS because it is render blocking resource: Google fonts
  - Reduce the impact of third-party code which may block main thread: webfont.js
- Therefore, we regress to adobe font which does not uses CSS but a async script instead and does not need the webfont.js which is a third-party font loader.

## Reference
- Reduce unused CSS
<img width="997" alt="image" src="https://user-images.githubusercontent.com/6375655/196017053-7b38781f-c5fb-4f6f-bc78-7b787a8e99fd.png">
