### PR TITLE
fix: latest tag order

### DIFF
--- a/src/containers/Latest.js
+++ b/src/containers/Latest.js
@@ -257,18 +257,15 @@ function titleTabProp(state, listId) {
   let latestTagList = [{ text: '全部', link: '/latest', isExternal: false }]
   latestTagList = _.concat(
     latestTagList,
-    _.sortBy(
-      _.map(latestTag, tag => {
-        const { id, name } = tag
-        return {
-          id,
-          text: name,
-          link: `/latest/${id}`,
-          isExternal: false,
-        }
-      }),
-      ['latest_order']
-    )
+    _.map(_.sortBy(latestTag, ['latest_order']), tag => {
+      const { id, name } = tag
+      return {
+        id,
+        text: name,
+        link: `/latest/${id}`,
+        isExternal: false,
+      }
+    })
   )
   const activeTabIndex = listId ? _.findIndex(latestTagList, ['id', listId]) : 0
 


### PR DESCRIPTION
This patch fix [[defect] keystone 最新頁顯示的排序與主網站不一致](https://app.asana.com/0/0/1203964075873147/f)