### PR TITLE
fix: kids reporter name in about us page

### DIFF
--- a/src/components/about-us/constants/section-02/categories.js
+++ b/src/components/about-us/constants/section-02/categories.js
@@ -61,7 +61,7 @@ const categories = [
     id: categoryIds.contentDevelopment,
     label: {
       english: 'Content Development',
-      chinese: '分 眾 報',
+      chinese: '少 年 報 導 者',
     },
   },
   {


### PR DESCRIPTION
# Issue
[[spec change] 將分眾報區塊名稱改為「少年報導者」](https://app.asana.com/0/1202936421725081/1204619216430521/f)

# Dependency
N/A
