### PR TITLE
refactor: update response Cache-Control header value

### DIFF
--- a/src/express/server.js
+++ b/src/express/server.js
@@ -198,7 +198,7 @@ class ExpressServer {
             res.header('Cache-Control', 'no-store')
           } else {
             // set Cache-Control header for caching
-            res.header('Cache-Control', 'public, max-age=300')
+            res.header('Cache-Control', 'public, max-age=0, s-maxage=300')
           }
         }
         next()


### PR DESCRIPTION
# Issue
當使用者在首頁（https://staging.twreporter.org ）登入網站後，將登入的 tab 關閉（瀏覽器上沒有報導者網頁的 tab），再另開新的 tab 時，重新輸入首頁網址（https://staging.twreporter.org ），網頁會呈現沒有登入的狀態。
比較詭異的部分是，如果瀏覽器上
- 仍有 tab 開著報導者網頁或是
- 重新整理沒有登入狀態的網頁

上述的問題就不會出現。

# 問題說明
因為使用者第一次點到首頁時，首頁的 response header 帶有 `Cache-Control: public, max-age=300`，所以瀏覽器會將首頁的 response cache 在瀏覽器上。
當我們另開 tab 時，瀏覽器不會發 request 到 origin server，而是選用 cache 的版本，然而，cache 的版本是沒有登入狀態的 html，所以網頁無法維持登入狀態。

# 修改說明
將 `max-age=300` 改成 `max-age=0`，強制瀏覽器發送 request。
但這個會增加 server loading，所以加上 `s-maxage=300`，讓 cloudflare CDN 還是儲存 cache；
只不過 cloudflare 的 Page Rule 有設定「當 request cookie 帶有 `id_token` 時，會 bypass cache」，
所以當使用者是登入的狀態時，不會拿到 cache。

# Notice
- 這是一個測試性的 commit，需要上 staging 驗證。
