### PR TITLE
fix: get slug from post for canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 4.12.9, 2024-04-08 (Current)
+## 4.12.10, 2024-04-10 (Current)
+
+### Notable Changes
+
+- fix
+  - get slug from post for canonical
+
+### Commits
+
+- [[`495e85eab4`](https://github.com/twreporter/twreporter-react/commit/495e85eab4)] - **fix**: get slug from post for canonical (Lucien)
+
+## 4.12.9, 2024-04-08
 
 ### Notable Changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "4.12.9",
+  "version": "4.12.10",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",

--- a/src/containers/Article-new.js
+++ b/src/containers/Article-new.js
@@ -352,7 +352,7 @@ const Article = ({
 
   post.style = uiManager.getArticleV2Style(post.style)
   // for head tag
-  const canonical = `${siteMeta.urlOrigin}/a/${slugToFetch}`
+  const canonical = `${siteMeta.urlOrigin}/a/${_.get(post, 'slug', '')}`
   const ogTitle = `${_.get(post, 'og_title', '') || _.get(post, 'title', '')}${
     siteMeta.name.separator
   }${siteMeta.name.full}`


### PR DESCRIPTION
# Issue
Article page canonical tag got empty slug

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
