### PR TITLE
fix: unexpected DOMExceptionError due to rendering promote `Banner`

### DIFF
--- a/src/components/membership-promo/index.js
+++ b/src/components/membership-promo/index.js
@@ -30,9 +30,11 @@ const MembershipPromo = ({ pathname, isAuthed, showHamburger }) => {
   const contextValue = { isShowPromo, closePromo }
   const Promo = promoType === PromoType.POPUP ? Popup : Banner
   return (
-    <PromoContext.Provider value={contextValue}>
-      <Promo />
-    </PromoContext.Provider>
+    <div>
+      <PromoContext.Provider value={contextValue}>
+        <Promo />
+      </PromoContext.Provider>
+    </div>
   )
 }
 MembershipPromo.propTypes = {


### PR DESCRIPTION
# Notice
This bug is hard to reproduce.

Currently, we are not so sure what kind of environment will trigger this error.

However, my computer is macOS and its os version is v14.5.

In this situation, when react renders `Banner` promote component, rather than `Popup` component, the DOMExceptionError occurs.

This patch is simply add `<div>` outside `<PromoContext.Provider>` to make sure that react will find a parent node where to replace `Popup` component to `Banner` under.

# Error logs
```
use-promo.js:40 DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at ol (https://www.twreporter.org/dist/vendors~main.c90291763dcd8b950263.chunk.js:83:94681)
    at rl (https://www.twreporter.org/dist/vendors~main.c90291763dcd8b950263.chunk.js:83:94385)
    at ol (https://www.twreporter.org/dist/vendors~main.c90291763dcd8b950263.chunk.js:83:95144)
    at rl (https://www.twreporter.org/dist/vendors~main.c90291763dcd8b950263.chunk.js:83:94385)
    at ol (https://www.twreporter.org/dist/vendors~main.c90291763dcd8b950263.chunk.js:83:95336)
    at rl (https://www.twreporter.org/dist/vendors~main.c90291763dcd8b950263.chunk.js:83:94385)
    at ol (https://www.twreporter.org/dist/vendors~main.c90291763dcd8b950263.chunk.js:83:95144)
    at rl (https://www.twreporter.org/dist/vendors~main.c90291763dcd8b950263.chunk.js:83:94385)
    at ol (https://www.twreporter.org/dist/vendors~main.c90291763dcd8b950263.chunk.js:83:95468)
    at rl (https://www.twreporter.org/dist/
```

# Issue
[[defect] 官網進去之後，js error handling 有問題，會白畫面](https://app.asana.com/0/1203699264568808/1207380201022309/f)