### PR TITLE
fix: remove cdn.polyfill.io script for security issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.0.6-rc.0, 2024-07-03
+
+- fix
+  - remove cdn.polyfill.io script for security issue
+
+### Commits
+
+- [[`e4e5e9e489`](https://github.com/twreporter/twreporter-react/commit/e4e5e9e489)] - **fix**: remove cdn.polyfill.io script for security issue (nickhsine)
+
 ## 5.0.5, 2024-06-25 (Current)
 
 ### Notable Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "5.0.5",
+  "version": "5.0.6-rc.0",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",

--- a/src/html.js
+++ b/src/html.js
@@ -112,10 +112,6 @@ export default class Html extends PureComponent {
         <body>
           <div id="root" dangerouslySetInnerHTML={{ __html: contentMarkup }} />
           <script
-            defer
-            src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.zh-Hant-TW"
-          />
-          <script
             dangerouslySetInnerHTML={{
               __html: `window.__REDUX_STATE__=${serialize(store.getState())};`,
             }}


### PR DESCRIPTION
# Issue
資安公司回報，我們網站用了 cdn.polyfill.io 的 javascript polyfill，而該 polyfill 含有惡意 javascript 程式。
相關文章：
1. [請儘速遠離cdn.polyfill.io 之惡意程式碼淺析](https://blog.huli.tw/2024/06/25/stop-using-polyfill-io/)
2. [【資安日報】6月28日，前幾天Polyfill.io供應鏈攻擊事件曝光 ...](https://www.ithome.com.tw/news/163709)

# Notice
剛剛測試，目前 cdn.polyfill.io 的網址是拿不到 javascript polyfill 的（見下圖）

<img width="748" alt="截圖 2024-07-03 上午11 50 12" src="https://github.com/twreporter/twreporter-react/assets/3000343/509969f9-dd94-4e25-b2b6-8e5b01b7478c">

加上該 polyfill 主要是給很舊的瀏覽器使用，例如 IE 11。
所以我們先移除此 polyfill 的使用，如有使用者回報問題，我們再找適合的 polyfill 來使用。




