### PR TITLE
fix: use createSelector to avoid rerender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 5.2.2-rc.2, 2024-11-18
+
+### Notable Changes
+
+- fix
+  - use createSelector to avoid rerender
+
+### Commits
+
+- [[`cab0632daf`](https://github.com/twreporter/twreporter-react/commit/cab0632daf)] - **fix**: use createSelector to avoid rerender (Lucien)
+
 ## 5.2.2-rc.1, 2024-11-13
 
 ### Notable Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "5.2.2-rc.1",
+  "version": "5.2.2-rc.2",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",


### PR DESCRIPTION
# Issue
[文章頁｜header 收合/展開效果異常](https://app.asana.com/0/1203699264568808/1208761465986478/f)

# Notice
from 官網範例
```javascript
function TodoList() {
  // ❌ WARNING: this _always_ returns a new reference, so it will _always_ re-render!
  const completedTodos = useSelector(state =>
    state.todos.map(todo => todo.completed)
  )
}
```
[ref](https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization)

# Dependency
<!-- Related dependency of this PR -->
