### PR TITLE
 feat: support on-demand yearly receipt generation on donation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 5.3.0-rc.0, 2026-04-24
+
+### Notable Changes
+
+- feat
+  - support on-demand yearly receipt generation on donation page
+
+### Commits
+
+- [[`b9c70e2ccd`](https://github.com/twreporter/twreporter-react/commit/b9c70e2ccd)] - **refactor**: remove email query param from yearly receipt POST fallback (nickhsine)
+- [[`4977cb646c`](https://github.com/twreporter/twreporter-react/commit/4977cb646c)] - **fix**: apply same code changes to index-old.js (nickhsine)
+- [[`0ee07f6696`](https://github.com/twreporter/twreporter-react/commit/0ee07f6696)] - **feat**: support on-demand yearly receipt generation (nickhsine)
+
 ## 5.2.24, 2026-04-09 (Current)
 
 ### Notable Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-react",
-  "version": "5.2.24",
+  "version": "5.3.0-rc.0",
   "description": "React-Redux site for The Reporter Foundation in Taiwan",
   "scripts": {
     "build": "make build",

--- a/src/components/member-page/donation/index-old.js
+++ b/src/components/member-page/donation/index-old.js
@@ -1,9 +1,10 @@
-import React, { useEffect, useState, useContext } from 'react'
+import React, { useEffect, useRef, useState, useContext } from 'react'
 import styled from 'styled-components'
 import { useSelector, useDispatch } from 'react-redux'
 import { createSelector } from '@reduxjs/toolkit'
 import querystring from 'querystring'
 import { useLocation } from 'react-router-dom'
+import axios from 'axios'
 import dayjs from 'dayjs'
 // @twreporter
 import { H3 } from '@twreporter/react-components/lib/text/headline'
@@ -110,6 +111,9 @@ const MemberDonationPage = () => {
   )
   const { userID, email, jwt } = useSelector(userInfoSelector)
   const { totalDonationHistory } = useSelector(totalDonationSelector)
+  const apiOrigin = useSelector(state =>
+    _.get(state, [reduxStateFields.origins, 'api'])
+  )
 
   const [records, setRecords] = useState([])
   const [showEmptyState, setShowEmptyState] = useState(false)
@@ -117,7 +121,11 @@ const MemberDonationPage = () => {
   const [isYearlyReceiptDownloading, setIsYearlyReceiptDownloading] = useState(
     false
   )
+  const [isYearlyReceiptGenerating, setIsYearlyReceiptGenerating] = useState(
+    false
+  )
   const [yearlyDownloadTextYear, setYearlyDownloadTextYear] = useState(0)
+  const yearlyReceiptGeneratingTimerRef = useRef(null)
 
   const [downloadYearlyReceiptTrigger, ,] = useLazyGetYearlyReceiptQuery()
 
@@ -149,11 +157,10 @@ const MemberDonationPage = () => {
   }
 
   const handleYearlyReceiptDownload = async () => {
-    if (isYearlyReceiptDownloading) {
+    if (isYearlyReceiptDownloading || isYearlyReceiptGenerating) {
       return
     }
     setIsYearlyReceiptDownloading(true)
-    toastr({ text: '收據開立中，開立完成會自動下載' })
 
     try {
       const result = await downloadYearlyReceiptTrigger({
@@ -161,6 +168,12 @@ const MemberDonationPage = () => {
         email,
         jwt,
       }).unwrap()
+
+      if (yearlyReceiptGeneratingTimerRef.current) {
+        clearTimeout(yearlyReceiptGeneratingTimerRef.current)
+        yearlyReceiptGeneratingTimerRef.current = null
+      }
+      setIsYearlyReceiptGenerating(false)
 
       const url = window.URL.createObjectURL(result)
       const link = document.createElement('a')
@@ -171,11 +184,77 @@ const MemberDonationPage = () => {
       document.body.removeChild(link)
       window.URL.revokeObjectURL(link.href)
     } catch (err) {
-      console.error('download receipt failed. err:', err)
+      // If the receipt file doesn't exist yet (404), trigger on-demand generation.
+      // The generation is async on the server side; notify the user to retry in a moment.
+      if (err && err.status === 404) {
+        if (!apiOrigin) {
+          console.error('yearly receipt generation: API origin not configured')
+          toastr({
+            text:
+              '收據下載失敗，請稍後再試，或來信 contact@twreporter.org 由專人協助',
+          })
+        } else {
+          try {
+            await axios.post(
+              `${apiOrigin}/v1/donations/receipt/${yearlyDownloadTextYear}?email=${encodeURIComponent(
+                email
+              )}`,
+              null,
+              {
+                withCredentials: true,
+                headers: { Authorization: `Bearer ${jwt}` },
+                timeout: 8000,
+              }
+            )
+            // axios resolves only on 2xx; reaching here means receipt generation started
+            setIsYearlyReceiptGenerating(true)
+            toastr({ text: '收據製作中，請 1 分鐘後再次點擊' })
+            if (yearlyReceiptGeneratingTimerRef.current) {
+              clearTimeout(yearlyReceiptGeneratingTimerRef.current)
+            }
+            yearlyReceiptGeneratingTimerRef.current = setTimeout(() => {
+              setIsYearlyReceiptGenerating(false)
+              yearlyReceiptGeneratingTimerRef.current = null
+            }, 60 * 1000)
+          } catch (postErr) {
+            if (postErr?.response?.status === 404) {
+              // go-api proxies 404 from member-cms: no donations for this year,
+              // so a receipt can never be generated.
+              toastr({
+                text: `${yearlyDownloadTextYear} 年度無贊助紀錄，無法產生收據`,
+              })
+            } else {
+              console.error(
+                'failed to trigger yearly receipt generation:',
+                postErr
+              )
+              toastr({
+                text:
+                  '收據下載失敗，請稍後再試，或來信 contact@twreporter.org 由專人協助',
+              })
+            }
+          }
+        }
+      } else {
+        console.error('download receipt failed. err:', err)
+        toastr({
+          text:
+            '收據下載失敗，請稍後再試，或來信 contact@twreporter.org 由專人協助',
+        })
+      }
     } finally {
       setIsYearlyReceiptDownloading(false)
     }
   }
+
+  useEffect(() => {
+    return () => {
+      if (yearlyReceiptGeneratingTimerRef.current) {
+        clearTimeout(yearlyReceiptGeneratingTimerRef.current)
+        yearlyReceiptGeneratingTimerRef.current = null
+      }
+    }
+  }, [])
 
   useEffect(() => {
     // get donations
@@ -213,12 +292,16 @@ const MemberDonationPage = () => {
         <StyledH3 text="贊助紀錄" />
         {yearlyDownloadTextYear > 0 ? (
           <PillButton
-            text={`${yearlyDownloadTextYear}年度收據`}
+            text={
+              isYearlyReceiptGenerating
+                ? '收據製作中...'
+                : `${yearlyDownloadTextYear}年度收據`
+            }
             style={PillButton.Style.DARK}
             type={PillButton.Type.PRIMARY}
             size={PillButton.Size.S}
             loading={isYearlyReceiptDownloading}
-            disabled={isYearlyReceiptDownloading}
+            disabled={isYearlyReceiptDownloading || isYearlyReceiptGenerating}
             onClick={handleYearlyReceiptDownload}
           />
         ) : null}

--- a/src/components/member-page/donation/index-old.js
+++ b/src/components/member-page/donation/index-old.js
@@ -196,9 +196,7 @@ const MemberDonationPage = () => {
         } else {
           try {
             await axios.post(
-              `${apiOrigin}/v1/donations/receipt/${yearlyDownloadTextYear}?email=${encodeURIComponent(
-                email
-              )}`,
+              `${apiOrigin}/v1/donations/receipt/${yearlyDownloadTextYear}`,
               null,
               {
                 withCredentials: true,

--- a/src/components/member-page/donation/index.js
+++ b/src/components/member-page/donation/index.js
@@ -303,9 +303,7 @@ const MemberDonationPage = () => {
         } else {
           try {
             await axios.post(
-              `${apiOrigin}/v1/donations/receipt/${yearlyDownloadTextYear}?email=${encodeURIComponent(
-                email
-              )}`,
+              `${apiOrigin}/v1/donations/receipt/${yearlyDownloadTextYear}`,
               null,
               {
                 withCredentials: true,

--- a/src/components/member-page/donation/index.js
+++ b/src/components/member-page/donation/index.js
@@ -1,7 +1,8 @@
-import React, { useEffect, useState, useContext } from 'react'
+import React, { useEffect, useRef, useState, useContext } from 'react'
 import styled from 'styled-components'
 import { useSelector, useDispatch } from 'react-redux'
 import { createSelector } from '@reduxjs/toolkit'
+import axios from 'axios'
 import querystring from 'querystring'
 import { useLocation } from 'react-router-dom'
 import dayjs from 'dayjs'
@@ -212,11 +213,17 @@ const MemberDonationPage = () => {
   )
   const { userID, email, jwt } = useSelector(userInfoSelector)
   const { totalDonationHistory } = useSelector(totalDonationSelector)
+  const apiOrigin = useSelector(state =>
+    _.get(state, [reduxStateFields.origins, 'api'])
+  )
 
   const [records, setRecords] = useState([])
   const [showEmptyState, setShowEmptyState] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [isYearlyReceiptDownloading, setIsYearlyReceiptDownloading] = useState(
+    false
+  )
+  const [isYearlyReceiptGenerating, setIsYearlyReceiptGenerating] = useState(
     false
   )
   const [yearlyDownloadTextYear, setYearlyDownloadTextYear] = useState(0)
@@ -227,6 +234,7 @@ const MemberDonationPage = () => {
   )
 
   const [downloadYearlyReceiptTrigger, ,] = useLazyGetYearlyReceiptQuery()
+  const yearlyReceiptGeneratingTimerRef = useRef(null)
 
   const { toastr } = useContext(CoreContext)
 
@@ -256,11 +264,10 @@ const MemberDonationPage = () => {
   }
 
   const handleYearlyReceiptDownload = async () => {
-    if (isYearlyReceiptDownloading) {
+    if (isYearlyReceiptDownloading || isYearlyReceiptGenerating) {
       return
     }
     setIsYearlyReceiptDownloading(true)
-    toastr({ text: '收據開立中，開立完成會自動下載' })
 
     try {
       const result = await downloadYearlyReceiptTrigger({
@@ -268,6 +275,12 @@ const MemberDonationPage = () => {
         email,
         jwt,
       }).unwrap()
+
+      if (yearlyReceiptGeneratingTimerRef.current) {
+        clearTimeout(yearlyReceiptGeneratingTimerRef.current)
+        yearlyReceiptGeneratingTimerRef.current = null
+      }
+      setIsYearlyReceiptGenerating(false)
 
       const url = window.URL.createObjectURL(result)
       const link = document.createElement('a')
@@ -278,7 +291,64 @@ const MemberDonationPage = () => {
       document.body.removeChild(link)
       window.URL.revokeObjectURL(link.href)
     } catch (err) {
-      console.error('download receipt failed. err:', err)
+      // If the receipt file doesn't exist yet (404), trigger on-demand generation.
+      // The generation is async on the server side; notify the user to retry in a moment.
+      if (err && err.status === 404) {
+        if (!apiOrigin) {
+          console.error('yearly receipt generation: API origin not configured')
+          toastr({
+            text:
+              '收據下載失敗，請稍後再試，或來信 contact@twreporter.org 由專人協助',
+          })
+        } else {
+          try {
+            await axios.post(
+              `${apiOrigin}/v1/donations/receipt/${yearlyDownloadTextYear}?email=${encodeURIComponent(
+                email
+              )}`,
+              null,
+              {
+                withCredentials: true,
+                headers: { Authorization: `Bearer ${jwt}` },
+                timeout: 8000,
+              }
+            )
+            // axios resolves only on 2xx; reaching here means receipt generation started
+            setIsYearlyReceiptGenerating(true)
+            toastr({ text: '收據製作中，請 1 分鐘後再次點擊' })
+            if (yearlyReceiptGeneratingTimerRef.current) {
+              clearTimeout(yearlyReceiptGeneratingTimerRef.current)
+            }
+            yearlyReceiptGeneratingTimerRef.current = setTimeout(() => {
+              setIsYearlyReceiptGenerating(false)
+              yearlyReceiptGeneratingTimerRef.current = null
+            }, 60 * 1000)
+          } catch (postErr) {
+            if (postErr?.response?.status === 404) {
+              // go-api proxies 404 from member-cms: no donations for this year,
+              // so a receipt can never be generated.
+              toastr({
+                text: `${yearlyDownloadTextYear} 年度無贊助紀錄，無法產生收據`,
+              })
+            } else {
+              console.error(
+                'failed to trigger yearly receipt generation:',
+                postErr
+              )
+              toastr({
+                text:
+                  '收據下載失敗，請稍後再試，或來信 contact@twreporter.org 由專人協助',
+              })
+            }
+          }
+        }
+      } else {
+        console.error('download receipt failed. err:', err)
+        toastr({
+          text:
+            '收據下載失敗，請稍後再試，或來信 contact@twreporter.org 由專人協助',
+        })
+      }
     } finally {
       setIsYearlyReceiptDownloading(false)
     }
@@ -292,6 +362,15 @@ const MemberDonationPage = () => {
     setShowEmptyState(false)
     setShowOfflineDonationPopup(false)
   }
+
+  useEffect(() => {
+    return () => {
+      if (yearlyReceiptGeneratingTimerRef.current) {
+        clearTimeout(yearlyReceiptGeneratingTimerRef.current)
+        yearlyReceiptGeneratingTimerRef.current = null
+      }
+    }
+  }, [])
 
   useEffect(() => {
     // get donations
@@ -366,12 +445,16 @@ const MemberDonationPage = () => {
           ) : null}
           {yearlyDownloadTextYear > 0 ? (
             <DownloadYearlyReceiptButton
-              text={`${yearlyDownloadTextYear}收據`}
+              text={
+                isYearlyReceiptGenerating
+                  ? '收據製作中...'
+                  : `${yearlyDownloadTextYear}收據`
+              }
               style={PillButton.Style.DARK}
               type={PillButton.Type.PRIMARY}
               size={PillButton.Size.S}
               loading={isYearlyReceiptDownloading}
-              disabled={isYearlyReceiptDownloading}
+              disabled={isYearlyReceiptDownloading || isYearlyReceiptGenerating}
               onClick={handleYearlyReceiptDownload}
               rightIconComponent={<Download />}
             />


### PR DESCRIPTION
  ## Summary

  Update the member donation page so yearly receipt download can recover from a missing file by triggering on-demand generation.

  If the existing yearly receipt download request returns `404`, the page now calls the new backend POST endpoint to start receipt generation, then asks the user to retry after a short wait.

  ## What Changed

  - keep the existing yearly receipt download flow as the first attempt
  - when download returns `404`, call `POST /v1/donations/receipt/:year` to trigger generation
  - include bearer auth and cross-origin credentials on the POST request
  - add a temporary "generating" state to prevent repeated clicks while receipt generation is pending
  - update the yearly receipt button text to `收據製作中...` during the pending window
  - show clearer toast messages for:
    - generation started
    - no donation data for that year
    - generic failure
  - clear the generation timer after a successful download and on component unmount

  ## Why

  Previously, the donation page assumed the yearly receipt PDF already existed.

  With the new backend flow, the frontend can recover when the file is not ready yet:
  1. try downloading the receipt
  2. if the file is missing, trigger generation
  3. ask the user to retry after the backend finishes producing the PDF

  This makes receipt download more resilient without changing the normal success path.

  ## Related

  - member-cms: https://github.com/twreporter/member-private-monorepo/pull/406
  - go-api: https://github.com/twreporter/go-api/pull/940


  ## Testing

  - verified normal receipt download still works when the file already exists
  - verified `404` download fallback triggers receipt generation
  - verified repeated clicks are blocked while generation is pending
  - verified `404` from generation shows the no-donation message
  - verified timer cleanup after success and unmount
